### PR TITLE
Create fluid typography utilities and apply across landing sections

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -51,3 +51,32 @@ section { scroll-snap-align: start; }
   will-change: transform, opacity;
   transform: translateZ(0);
 }
+
+/* ===== Tipografia fluida ===== */
+@layer base {
+  :root {
+    --heading-xl: clamp(2rem, calc(1.4rem + 3vw), 4.5rem);
+    --heading-lg: clamp(1.65rem, calc(1.1rem + 2vw), 2.75rem);
+    --subheading: clamp(1.0625rem, calc(0.95rem + 0.5vw), 1.375rem);
+  }
+}
+
+@layer utilities {
+  .heading-xl {
+    font-size: var(--heading-xl);
+    line-height: 1.05;
+    letter-spacing: -0.045em;
+  }
+
+  .heading-lg {
+    font-size: var(--heading-lg);
+    line-height: 1.12;
+    letter-spacing: -0.03em;
+  }
+
+  .subheading {
+    font-size: var(--subheading);
+    line-height: 1.65;
+    letter-spacing: -0.01em;
+  }
+}

--- a/src/sections/CallToActionEco.tsx
+++ b/src/sections/CallToActionEco.tsx
@@ -7,7 +7,7 @@ const CallToActionEco: React.FC = () => {
       id="convite"
       className="
         relative overflow-hidden
-        w-full py-16 sm:py-20 px-6
+        w-full py-16 sm:py-20 px-5 sm:px-8 md:px-12
         flex flex-col items-center text-center
         mx-auto max-w-5xl
         rounded-[32px] border border-white/60
@@ -22,8 +22,8 @@ const CallToActionEco: React.FC = () => {
       </div>
 
       {/* Título + subtítulo */}
-      <div className="relative max-w-3xl">
-        <h2 className="text-[28px] sm:text-[36px] md:text-[44px] font-semibold leading-tight tracking-tight text-[#0A0C18]">
+      <div className="relative max-w-3xl md:max-w-2xl">
+        <h2 className="heading-lg font-semibold text-[#0A0C18]">
           Descubra a{" "}
           <span className="bg-[linear-gradient(90deg,#7C5CFF,#5B4BFF)] bg-clip-text text-transparent">
             Eco
@@ -31,7 +31,7 @@ const CallToActionEco: React.FC = () => {
           antes de todo mundo
         </h2>
 
-        <p className="mt-4 text-[15px] sm:text-[17px] text-[#505467]">
+        <p className="mt-4 subheading text-[#505467]">
           Acesse gratuitamente a versão beta — uma jornada de autoconhecimento
           com IA, feita para quem quer se escutar com profundidade.
         </p>

--- a/src/sections/EmotionalReportSection.tsx
+++ b/src/sections/EmotionalReportSection.tsx
@@ -191,7 +191,7 @@ const EmotionalReportSection: React.FC = () => {
         {/* Título e subtítulo */}
         <h2
           className={`
-            text-[26px] sm:text-4xl md:text-[44px] font-semibold tracking-tight
+            heading-lg font-semibold
             text-neutral-900 text-center lg:text-left
             transition-all duration-700 mb-3
             ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}
@@ -205,8 +205,7 @@ const EmotionalReportSection: React.FC = () => {
 
         <p
           className={`
-            text-[15px] sm:text-[17px] lg:text-[18px] leading-relaxed
-            text-neutral-600 max-w-3xl
+            subheading text-neutral-600 max-w-3xl
             text-center lg:text-left mb-8
             transition-all duration-700 delay-100
             ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}

--- a/src/sections/ForWhoSection.tsx
+++ b/src/sections/ForWhoSection.tsx
@@ -103,17 +103,14 @@ const TargetAudienceSection: React.FC = () => {
 
       {/* Header alinhado à esquerda (como o "como funciona") */}
       <div className="relative w-full max-w-7xl mx-auto mb-8 sm:mb-12 text-left">
-        <h2
-          id="para-quem-title"
-          className="text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight"
-        >
+        <h2 id="para-quem-title" className="heading-lg font-semibold">
           <span className="text-zinc-900">Quando a </span>
           <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">
             Eco
           </span>
           <span className="text-zinc-900"> ajuda.</span>
         </h2>
-        <p className="mt-2 text-zinc-900 text-[15px] sm:text-[17px] max-w-2xl">
+        <p className="mt-2 subheading text-zinc-900 max-w-2xl">
           Quatro situações do dia a dia. {sub}
         </p>
       </div>

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -58,32 +58,18 @@ const HeroSection: React.FC = () => {
         </span>
 
         {/* Título */}
-        <h1
-          id="hero-title"
-          className="
-            text-balance
-            text-[32px] leading-[1.36]
-            sm:text-6xl sm:leading-tight lg:text-7xl
-            tracking-tight mb-4 sm:mb-6
-          "
-        >
+        <h1 id="hero-title" className="text-balance heading-xl mb-4 sm:mb-6">
           <span className="font-extrabold text-zinc-900">Eco.</span>{" "}
           <span className="font-medium text-zinc-700">Sua jornada começa aqui.</span>
         </h1>
 
         {/* Subtítulo */}
-        <p
-          className="
-            text-[17px] leading-[1.85] sm:text-xl sm:leading-relaxed
-            text-zinc-600 max-w-[46ch] sm:max-w-[680px]
-            mb-12 sm:mb-10
-          "
-        >
+        <p className="subheading text-zinc-600 max-w-[48ch] sm:max-w-[680px] mb-12 sm:mb-10">
           Escreva, reflita e descubra padrões — simples, guiado e no seu ritmo.
         </p>
 
         {/* CTAs */}
-        <div className="w-full flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-5 mb-7 sm:mb-9">
+        <div className="w-full flex flex-col sm:flex-row sm:flex-wrap md:flex-nowrap items-center justify-center gap-4 sm:gap-5 md:gap-6 mb-7 sm:mb-9">
           {/* CTA com o link ajustado */}
           <a
             href="https://ecofrontend888.vercel.app/login"

--- a/src/sections/HowItWorksSection.tsx
+++ b/src/sections/HowItWorksSection.tsx
@@ -94,14 +94,14 @@ const HowItWorks: React.FC = () => {
           isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
         }`}
       >
-        <h2 className="text-left text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight">
-  <span className="text-zinc-900">Como a Eco</span>
-  {" "}
+        <h2 className="text-left heading-lg font-semibold">
+          <span className="text-zinc-900">Como a Eco</span>
+          {" "}
           <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">
-    funciona.
-  </span>
+            funciona.
+          </span>
         </h2>
-        <p className="mt-2 text-left text-zinc-500 text-[15px] sm:text-[17px]">
+        <p className="mt-2 subheading text-left text-zinc-500">
           Os passos. Do primeiro registro à clareza.
         </p>
       </div>

--- a/src/sections/IntroducingEco.tsx
+++ b/src/sections/IntroducingEco.tsx
@@ -53,11 +53,11 @@ const IntroducingEco: React.FC = () => {
 
       {/* Título + subtítulo */}
       <div className="relative w-full max-w-7xl mx-auto text-left mb-8 sm:mb-12">
-        <h2 className="text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight">
+        <h2 className="heading-lg font-semibold">
           <span className="text-zinc-900">Conheça a </span>
           <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">Eco</span>
         </h2>
-        <p className="mt-2 text-zinc-500 text-[15px] sm:text-[17px] max-w-3xl">
+        <p className="mt-2 subheading text-zinc-500 max-w-3xl">
           Um espaço simples e guiado para escrever, refletir e enxergar padrões — criando condições reais para mudança.
         </p>
       </div>

--- a/src/sections/MentoresStrip.tsx
+++ b/src/sections/MentoresStrip.tsx
@@ -107,7 +107,7 @@ const MentoresStrip: React.FC = () => {
             Referências • Base das respostas
           </span>
 
-          <h2 id="mentores-title" className="mt-4 font-semibold tracking-tight text-2xl sm:text-4xl">
+          <h2 id="mentores-title" className="mt-4 heading-lg font-semibold text-white">
             <span className="text-white">Grandes mentes.</span>
             <span className="text-white/70"> As ideias que inspiram a Eco.</span>
           </h2>

--- a/src/sections/PrinciplesSection.tsx
+++ b/src/sections/PrinciplesSection.tsx
@@ -67,13 +67,13 @@ const PrinciplesSection: React.FC = () => {
 
       {/* Título + subtítulo */}
       <div className="relative max-w-4xl mx-auto text-center mb-10 sm:mb-12">
-        <h2 className="text-[28px] sm:text-[36px] lg:text-[42px] font-semibold leading-tight tracking-tight">
+        <h2 className="heading-lg font-semibold">
           <span className="text-[#1D1D1F]">Nossos </span>
           <span className="bg-[linear-gradient(90deg,#7C5CFF,#5B4BFF)] bg-clip-text text-transparent">
             Princípios
           </span>
         </h2>
-        <p className="mt-3 text-[#6E6E73] text-[15px] sm:text-[17px] max-w-2xl mx-auto">
+        <p className="mt-3 subheading text-[#6E6E73] max-w-2xl mx-auto">
           Segurança, presença e profundidade para oferecer um espaço confiável
           onde você possa se ouvir com clareza.
         </p>

--- a/src/sections/Testimonials.tsx
+++ b/src/sections/Testimonials.tsx
@@ -148,13 +148,13 @@ const Testimonials: React.FC = () => {
       <div className="relative max-w-5xl mx-auto">
         {/* Header */}
         <div className="flex flex-col items-center text-center">
-          <h2 className="text-[28px] sm:text-[36px] md:text-[44px] font-semibold leading-tight tracking-tight text-[#0F111A]">
+          <h2 className="heading-lg font-semibold text-[#0F111A]">
             O que as pessoas sentem com a{" "}
             <span className="bg-[linear-gradient(90deg,#7C5CFF,#5B4BFF)] bg-clip-text text-transparent">
               Eco
             </span>
           </h2>
-          <p className="mt-3 text-[15px] sm:text-[17px] text-[#565A66] max-w-xl">
+          <p className="mt-3 subheading text-[#565A66] max-w-xl">
             Feedbacks reais de quem experimentou. Simples, seguros e anônimos.
           </p>
         </div>


### PR DESCRIPTION
## Summary
- add fluid clamp-based heading and subheading utilities to the global stylesheet
- replace repeated heading/subheading text-size stacks in hero, testimonials, CTA and other sections with the new utilities
- tweak CTA container spacing and hero CTA flex behavior to keep layouts balanced across medium breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d939cb175c8325b38fd23616ed590e