### PR TITLE
Use SF Pro system fonts for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ECO - Experiência de Autoconhecimento</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -124,7 +124,7 @@ const Footer: React.FC = () => {
             <div className="grid grid-cols-2 md:grid-cols-3 gap-10">
               {columns.map((col) => (
                 <div key={col.title}>
-                  <h3 className="text-[12px] font-medium uppercase tracking-wider text-slate-500 mb-3">
+                  <h3 className="text-[12px] font-heading uppercase tracking-wider text-slate-500 mb-3">
                     {col.title}
                   </h3>
                   <ul className="space-y-2.5">

--- a/src/components/IconCard.tsx
+++ b/src/components/IconCard.tsx
@@ -13,7 +13,7 @@ const IconCard: React.FC<IconCardProps> = ({ icon, title, description }) => {
         {icon}
       </div>
       <div>
-        <h3 className="text-xl font-medium text-gray-800 mb-1">{title}</h3>
+        <h3 className="text-xl font-heading text-gray-800 mb-1">{title}</h3>
         <p className="text-gray-600">{description}</p>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ===== Fontes ===== */
+:root {
+  --font-sf: 'SF Pro Display', 'SF Pro Text', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI',
+    'system-ui', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif';
+}
+
+@layer utilities {
+  .font-heading {
+    font-family: var(--font-sf);
+    font-weight: 600;
+  }
+
+  .font-heading-strong {
+    font-family: var(--font-sf);
+    font-weight: 700;
+  }
+}
+
 /* ===== Globais de UX/Performance ===== */
 html {
   /* rolagem suave nativa p/ anchors */

--- a/src/pages/ReflexaoPage.tsx
+++ b/src/pages/ReflexaoPage.tsx
@@ -89,7 +89,7 @@ const AcessoAntecipadoPage: React.FC = () => {
         </div>
 
         <div className="relative z-10 w-full max-w-2xl bg-white/5 border border-white/10 backdrop-blur-md rounded-2xl shadow-2xl p-8">
-          <h1 className="text-3xl md:text-4xl font-extrabold text-white tracking-tight mb-4 text-center lg:text-left">
+          <h1 className="text-3xl md:text-4xl font-heading-strong text-white tracking-tight mb-4 text-center lg:text-left">
             Convite para o Acesso Antecipado à <span className="text-indigo-400">Eco</span>
           </h1>
           <p className="text-gray-300 mb-8 text-center lg:text-left leading-relaxed">

--- a/src/sections/CallToActionEco.tsx
+++ b/src/sections/CallToActionEco.tsx
@@ -23,7 +23,7 @@ const CallToActionEco: React.FC = () => {
 
       {/* Título + subtítulo */}
       <div className="relative max-w-3xl">
-        <h2 className="text-[28px] sm:text-[36px] md:text-[44px] font-semibold leading-tight tracking-tight text-[#0A0C18]">
+        <h2 className="text-[28px] sm:text-[36px] md:text-[44px] font-semibold leading-tight tracking-tight text-[#0A0C18] font-heading-strong">
           Descubra a{" "}
           <span className="bg-[linear-gradient(90deg,#7C5CFF,#5B4BFF)] bg-clip-text text-transparent">
             Eco

--- a/src/sections/EmotionalReportSection.tsx
+++ b/src/sections/EmotionalReportSection.tsx
@@ -194,6 +194,7 @@ const EmotionalReportSection: React.FC = () => {
             text-[26px] sm:text-4xl md:text-[44px] font-semibold tracking-tight
             text-neutral-900 text-center lg:text-left
             transition-all duration-700 mb-3
+            font-heading-strong
             ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}
           `}
         >

--- a/src/sections/ForWhoSection.tsx
+++ b/src/sections/ForWhoSection.tsx
@@ -105,7 +105,7 @@ const TargetAudienceSection: React.FC = () => {
       <div className="relative w-full max-w-7xl mx-auto mb-8 sm:mb-12 text-left">
         <h2
           id="para-quem-title"
-          className="text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight"
+          className="text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight font-heading-strong"
         >
           <span className="text-zinc-900">Quando a </span>
           <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">
@@ -133,7 +133,7 @@ const TargetAudienceSection: React.FC = () => {
               <div className="relative flex items-start gap-4 sm:gap-5">
                 <IconBadge Icon={c.Icon} accent={c.accent} />
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-[#1D1D1F] font-semibold tracking-tight text-[18px] sm:text-[20px] lg:text-[22px]">
+                  <h3 className="text-[#1D1D1F] font-heading tracking-tight text-[18px] sm:text-[20px] lg:text-[22px]">
                     {c.title}
                   </h3>
                   {/* Sinais ↔ O que muda (altura fixa) */}

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -65,9 +65,10 @@ const HeroSection: React.FC = () => {
             text-[32px] leading-[1.36]
             sm:text-6xl sm:leading-tight lg:text-7xl
             tracking-tight mb-4 sm:mb-6
+            font-heading-strong
           "
         >
-          <span className="font-extrabold text-zinc-900">Eco.</span>{" "}
+          <span className="text-zinc-900">Eco.</span>{" "}
           <span className="font-medium text-zinc-700">Sua jornada começa aqui.</span>
         </h1>
 

--- a/src/sections/HowItWorksSection.tsx
+++ b/src/sections/HowItWorksSection.tsx
@@ -94,7 +94,7 @@ const HowItWorks: React.FC = () => {
           isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
         }`}
       >
-        <h2 className="text-left text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight">
+        <h2 className="text-left text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight font-heading-strong">
   <span className="text-zinc-900">Como a Eco</span>
   {" "}
           <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">
@@ -137,7 +137,7 @@ const HowItWorks: React.FC = () => {
 
                 <div className="flex-1">
                   <div className="flex items-baseline gap-2">
-                    <h3 className="text-[16px] text-zinc-900 font-medium leading-snug">{step.title}</h3>
+                    <h3 className="text-[16px] text-zinc-900 font-heading leading-snug">{step.title}</h3>
                     <span className="ml-auto text-[12px] text-zinc-400 tabular-nums">0{step.id}</span>
                   </div>
                   <p className="text-zinc-600 text-[13px] leading-snug line-clamp-2">{step.description}</p>
@@ -190,7 +190,7 @@ const HowItWorks: React.FC = () => {
                 </div>
                 <div className="flex-1">
                   <div className="flex items-baseline gap-2">
-                    <h3 className="text-[17px] text-zinc-900 font-medium leading-snug">{step.title}</h3>
+                    <h3 className="text-[17px] text-zinc-900 font-heading leading-snug">{step.title}</h3>
                     <span className="ml-auto text-[12px] text-zinc-400 tabular-nums">0{step.id}</span>
                   </div>
                   <p className="text-zinc-600 text-[15px] leading-snug">{step.description}</p>

--- a/src/sections/IntroducingEco.tsx
+++ b/src/sections/IntroducingEco.tsx
@@ -30,7 +30,7 @@ function FeatureCard({
         <div className="absolute inset-0 rounded-xl bg-[radial-gradient(80%_80%_at_30%_20%,rgba(124,92,255,0.18),transparent_55%)]" />
         <Icon size={20} strokeWidth={2} className="relative z-10 text-[#7C5CFF]" />
       </div>
-      <h4 className="mt-3 text-[15px] font-semibold text-[#0F111A]">{title}</h4>
+      <h4 className="mt-3 text-[15px] font-heading text-[#0F111A]">{title}</h4>
       <p className="mt-1.5 text-[13.5px] leading-relaxed text-[#4B5166]">{desc}</p>
     </div>
   );
@@ -53,7 +53,7 @@ const IntroducingEco: React.FC = () => {
 
       {/* Título + subtítulo */}
       <div className="relative w-full max-w-7xl mx-auto text-left mb-8 sm:mb-12">
-        <h2 className="text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight">
+        <h2 className="text-[26px] sm:text-4xl md:text-[44px] font-semibold leading-tight tracking-tight font-heading-strong">
           <span className="text-zinc-900">Conheça a </span>
           <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">Eco</span>
         </h2>
@@ -66,7 +66,7 @@ const IntroducingEco: React.FC = () => {
       <div className="relative max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-14 items-center">
         {/* Texto */}
         <div className="order-2 lg:order-1">
-          <p className="text-2xl sm:text-[28px] font-semibold text-[#0F111A] leading-snug">
+          <p className="text-2xl sm:text-[28px] font-heading text-[#0F111A] leading-snug">
             Você muda. <span className="text-zinc-900">A </span>
             <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">Eco</span>
             <span className="text-zinc-900"> cria as condições.</span>

--- a/src/sections/MentoresStrip.tsx
+++ b/src/sections/MentoresStrip.tsx
@@ -107,7 +107,10 @@ const MentoresStrip: React.FC = () => {
             Referências • Base das respostas
           </span>
 
-          <h2 id="mentores-title" className="mt-4 font-semibold tracking-tight text-2xl sm:text-4xl">
+          <h2
+            id="mentores-title"
+            className="mt-4 font-semibold tracking-tight text-2xl sm:text-4xl font-heading-strong"
+          >
             <span className="text-white">Grandes mentes.</span>
             <span className="text-white/70"> As ideias que inspiram a Eco.</span>
           </h2>
@@ -189,7 +192,7 @@ const MentoresStrip: React.FC = () => {
                     </span>
                   </div>
 
-                  <div className="text-white font-medium text-[15px] leading-tight">{m.name}</div>
+                  <div className="text-white font-heading text-[15px] leading-tight">{m.name}</div>
                   <div className="text-white/80 text-[12px]">{m.tag}</div>
 
                   {/* como aparece nas respostas */}
@@ -228,7 +231,7 @@ const MentoresStrip: React.FC = () => {
           "
           aria-label="Como a Eco usa essas referências nas respostas"
         >
-          <h3 className="font-medium mb-2">Como isso aparece na sua experiência</h3>
+          <h3 className="font-heading mb-2">Como isso aparece na sua experiência</h3>
           <ul className="list-disc pl-5 space-y-1 text-sm">
             <li>
               <span className="font-medium">Perguntas e reflexões guiadas</span> inspiradas em filosofia e psicologia — nada de respostas vazias.

--- a/src/sections/PrinciplesSection.tsx
+++ b/src/sections/PrinciplesSection.tsx
@@ -67,7 +67,7 @@ const PrinciplesSection: React.FC = () => {
 
       {/* Título + subtítulo */}
       <div className="relative max-w-4xl mx-auto text-center mb-10 sm:mb-12">
-        <h2 className="text-[28px] sm:text-[36px] lg:text-[42px] font-semibold leading-tight tracking-tight">
+        <h2 className="text-[28px] sm:text-[36px] lg:text-[42px] font-semibold leading-tight tracking-tight font-heading-strong">
           <span className="text-[#1D1D1F]">Nossos </span>
           <span className="bg-[linear-gradient(90deg,#7C5CFF,#5B4BFF)] bg-clip-text text-transparent">
             Princípios
@@ -96,7 +96,7 @@ const PrinciplesSection: React.FC = () => {
           >
             <div className="flex flex-col items-center text-center">
               <IconBadge Icon={Icon} />
-              <h3 className="mt-4 text-[18px] sm:text-[20px] font-semibold text-[#0F1115] tracking-tight">
+              <h3 className="mt-4 text-[18px] sm:text-[20px] font-heading text-[#0F1115] tracking-tight">
                 {title}
               </h3>
               <p className="mt-2 text-[14px] sm:text-[15px] leading-relaxed text-[#5E616B]">

--- a/src/sections/StressIndexSection.tsx
+++ b/src/sections/StressIndexSection.tsx
@@ -102,7 +102,7 @@ const StressIndexSection: React.FC = () => {
             viewport={{ once: true, amount: 0.4 }}
             className="
               mt-3
-              font-light tracking-[-0.01em]
+              font-heading tracking-[-0.01em]
               leading-[1.15]
               text-[clamp(26px,5.2vw,42px)]
               max-w-[26ch]

--- a/src/sections/Testimonials.tsx
+++ b/src/sections/Testimonials.tsx
@@ -148,7 +148,7 @@ const Testimonials: React.FC = () => {
       <div className="relative max-w-5xl mx-auto">
         {/* Header */}
         <div className="flex flex-col items-center text-center">
-          <h2 className="text-[28px] sm:text-[36px] md:text-[44px] font-semibold leading-tight tracking-tight text-[#0F111A]">
+          <h2 className="text-[28px] sm:text-[36px] md:text-[44px] font-semibold leading-tight tracking-tight text-[#0F111A] font-heading-strong">
             O que as pessoas sentem com a{" "}
             <span className="bg-[linear-gradient(90deg,#7C5CFF,#5B4BFF)] bg-clip-text text-transparent">
               Eco

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,18 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: [
+          'SF Pro Display',
+          'SF Pro Text',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'system-ui',
+          'Roboto',
+          'Helvetica Neue',
+          'Arial',
+          'sans-serif',
+        ],
       },
       colors: {
         purple: {


### PR DESCRIPTION
## Summary
- prioritize SF Pro system fonts in Tailwind and remove the Inter Google Font preload
- add reusable font-heading utilities and apply them across hero, sections, CTA, footer, and form headings for consistent weights

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d939dc6d6883258bea88e9ac62d966