### PR TITLE
feat: refresh hero and how it works styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,43 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ===== Fontes primárias ===== */
+@font-face {
+  font-family: "SF Pro Display";
+  font-style: normal;
+  font-weight: 400;
+  src: local("SF Pro Display Regular"), local("SFProDisplay-Regular"),
+    local(".SFNSDisplay"), local(".SFNSDisplay-Regular");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "SF Pro Display";
+  font-style: normal;
+  font-weight: 600;
+  src: local("SF Pro Display Semibold"), local("SFProDisplay-Semibold"),
+    local(".SFNSDisplay-Semibold");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "SF Pro Text";
+  font-style: normal;
+  font-weight: 400;
+  src: local("SF Pro Text Regular"), local("SFProText-Regular"),
+    local(".SFNSText"), local(".SFNSText-Regular");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "SF Pro Text";
+  font-style: normal;
+  font-weight: 500;
+  src: local("SF Pro Text Medium"), local("SFProText-Medium"),
+    local(".SFNSText-Medium");
+  font-display: swap;
+}
+
 /* ===== Globais de UX/Performance ===== */
 html {
   /* rolagem suave nativa p/ anchors */
@@ -58,6 +95,55 @@ section { scroll-snap-align: start; }
     --heading-xl: clamp(2rem, calc(1.4rem + 3vw), 4.5rem);
     --heading-lg: clamp(1.65rem, calc(1.1rem + 2vw), 2.75rem);
     --subheading: clamp(1.0625rem, calc(0.95rem + 0.5vw), 1.375rem);
+  }
+
+  body {
+    font-family: "SF Pro Text", "SF Pro Display", -apple-system,
+      BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    color: #111827;
+    background-color: #ffffff;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "SF Pro Display", "SF Pro Text", -apple-system,
+      BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    letter-spacing: -0.02em;
+  }
+
+  blockquote,
+  .quote-serif {
+    font-family: "EB Garamond", "EB Garamond Italic", "Times New Roman",
+      serif;
+    font-style: italic;
+  }
+}
+
+@layer components {
+  .glass {
+    @apply rounded-2xl border border-white/30 bg-white/40 backdrop-blur-xl shadow-sm;
+  }
+
+  .glass-hover {
+    @apply transform transition duration-300 ease-out hover:-translate-y-1 hover:bg-white/60 hover:shadow-lg;
+  }
+
+  .liquid-bg {
+    position: relative;
+    background-color: #ffffff;
+  }
+
+  .liquid-bg::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(167, 139, 250, 0.13), rgba(99, 102, 241, 0.07));
+    pointer-events: none;
+    z-index: 0;
   }
 }
 

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -17,7 +17,7 @@ const HeroSection: React.FC = () => {
       ref={ref}
       aria-labelledby="hero-title"
       className={`
-        relative overflow-hidden bg-white
+        relative overflow-hidden liquid-bg
         min-h-[calc(100svh-var(--nav-h,64px))] md:min-h-[calc(100dvh-var(--nav-h,80px))]
         [content-visibility:auto] [contain-intrinsic-size:1px_800px]
       `}
@@ -25,15 +25,16 @@ const HeroSection: React.FC = () => {
       {/* BG / ORB */}
       <div
         aria-hidden
-        className="
-          pointer-events-none absolute inset-0 flex items-center justify-center
-          transform-gpu will-change-transform
-        "
+        className="pointer-events-none absolute inset-0 z-[1]"
       >
-        <div className="relative w-[88vw] max-w-[560px] aspect-square">
-          <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(115,91,255,0.14)_0%,rgba(115,91,255,0.06)_45%,transparent_72%)] blur-xl sm:blur-2xl" />
-          <div className="absolute inset-0 opacity-20 sm:opacity-35 motion-reduce:opacity-0">
-            <Orb hoverIntensity={0.12} rotateOnHover={false} hue={265} forceHoverState={false} />
+        <div className="absolute -top-24 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-gradient-to-br from-purple-200 via-transparent to-indigo-200 opacity-60 blur-3xl" />
+        <div className="absolute inset-x-0 bottom-[-10%] h-[22rem] bg-gradient-to-t from-white/90 via-white/40 to-transparent" />
+        <div className="absolute inset-0 flex items-center justify-center transform-gpu will-change-transform">
+          <div className="relative w-[88vw] max-w-[560px] aspect-square">
+            <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle,rgba(115,91,255,0.18)_0%,rgba(115,91,255,0.08)_45%,transparent_72%)] blur-2xl" />
+            <div className="absolute inset-0 opacity-25 sm:opacity-40 motion-reduce:opacity-0">
+              <Orb hoverIntensity={0.12} rotateOnHover={false} hue={265} forceHoverState={false} />
+            </div>
           </div>
         </div>
       </div>
@@ -41,47 +42,38 @@ const HeroSection: React.FC = () => {
       {/* CONTEÚDO */}
       <div
         className={`
-          relative z-10 mx-auto px-5 sm:px-6
-          max-w-[520px] sm:max-w-[880px]
-          flex flex-col items-center text-center
-          pt-[calc(var(--nav-h,64px)+22px+env(safe-area-inset-top))]
-          md:pt-[calc(var(--nav-h,80px)+72px)]
-          pb-[calc(16px+env(safe-area-inset-bottom))] md:pb-20
+          relative z-10 mx-auto flex max-w-7xl flex-col items-center
+          px-4 sm:px-6 lg:px-8 text-center
+          pt-[calc(var(--nav-h,64px)+32px+env(safe-area-inset-top))]
+          md:pt-[calc(var(--nav-h,80px)+88px)]
+          pb-[calc(32px+env(safe-area-inset-bottom))]
+          md:pb-32
           transition-all duration-500 ease-out
-          ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"}
+          ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}
           transform-gpu will-change-[opacity,transform]
         `}
       >
         {/* Pílula */}
-        <span className="inline-flex items-center px-4 py-1.5 rounded-full mb-5 sm:mb-6 text-[12px] sm:text-sm font-medium text-zinc-700 bg-white/80 border border-zinc-200 backdrop-blur-sm shadow-sm">
-          Jornada de Autoconhecimento
+        <span className="glass inline-flex items-center gap-2 rounded-full px-5 py-2 text-xs font-medium uppercase tracking-[0.2em] text-[#6B7280]">
+          Jornada de autoconhecimento
         </span>
 
         {/* Título */}
-        <h1 id="hero-title" className="text-balance heading-xl mb-4 sm:mb-6">
-          <span className="font-extrabold text-zinc-900">Eco.</span>{" "}
-          <span className="font-medium text-zinc-700">Sua jornada começa aqui.</span>
+        <h1 id="hero-title" className="heading-xl mt-8 text-balance font-semibold text-[#111827]">
+          Eco, um espaço delicado para ler o que você sente.
         </h1>
 
         {/* Subtítulo */}
-        <p className="subheading text-zinc-600 max-w-[48ch] sm:max-w-[680px] mb-12 sm:mb-10">
-          Escreva, reflita e descubra padrões — simples, guiado e no seu ritmo.
+        <p className="subheading mt-6 max-w-2xl text-balance text-[#6B7280]">
+          Um diário inteligente com toques humanos: escreva, receba reflexões e acompanhe sua evolução emocional com suavidade.
         </p>
 
         {/* CTAs */}
-        <div className="w-full flex flex-col sm:flex-row sm:flex-wrap md:flex-nowrap items-center justify-center gap-4 sm:gap-5 md:gap-6 mb-7 sm:mb-9">
-          {/* CTA com o link ajustado */}
+        <div className="mt-10 flex w-full flex-col items-center justify-center gap-4 sm:mt-12 sm:flex-row sm:flex-wrap md:flex-nowrap md:gap-5">
           <a
             href="https://ecofrontend888.vercel.app/login"
             aria-label="Começar minha jornada"
-            className="
-              relative inline-flex w-full sm:w-auto items-center justify-center gap-2
-              h-12 px-7 rounded-full font-semibold text-white
-              bg-gradient-to-b from-[#7C5CFF] to-[#5B4BFF]
-              shadow-[0_12px_24px_rgba(91,75,255,0.26)]
-              hover:brightness-[1.07] active:scale-[0.99] transition
-              transform-gpu
-            "
+            className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#4F46E5] to-[#6366F1] px-8 py-3 text-base font-semibold text-white shadow-[0_18px_36px_rgba(99,102,241,0.28)] transition duration-300 ease-out hover:shadow-[0_22px_44px_rgba(99,102,241,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
           >
             <PlayCircle size={18} className="opacity-90" />
             Começar minha jornada
@@ -90,34 +82,29 @@ const HeroSection: React.FC = () => {
           <a
             href="#como-funciona"
             onClick={handleGoToHowItWorks}
-            className="
-              group relative inline-flex w-full sm:w-auto items-center justify-center gap-2
-              h-12 px-7 rounded-full font-semibold
-              bg-white text-zinc-900
-              ring-1 ring-[#E6E9F6]
-              shadow-sm hover:bg-[#F8FAFF] active:scale-[0.99] transition
-              cursor-pointer
-            "
+            className="group inline-flex w-full items-center justify-center gap-2 rounded-full border border-[#E0E7FF] bg-white/80 px-8 py-3 text-base font-semibold text-[#4F46E5] shadow-sm transition duration-300 ease-out hover:border-[#C7D2FE] hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
             aria-label="Ver como funciona"
           >
             Ver como funciona
-            <ChevronRight size={18} className="transition-transform duration-200 group-hover:translate-x-0.5" />
+            <ChevronRight size={18} className="transition-transform duration-300 group-hover:translate-x-1" />
           </a>
         </div>
 
         {/* Micro-confiança */}
-        <p className="text-[12px] sm:text-sm text-zinc-500 tracking-wide">
-          Beta gratuito · Teste em minutos · Vagas limitadas
-        </p>
+        <div className="mt-10 flex flex-wrap justify-center gap-3 text-xs font-medium text-[#6B7280] sm:text-sm">
+          <span className="glass px-4 py-1.5">Beta gratuito</span>
+          <span className="glass px-4 py-1.5">Relatórios emocionais guiados</span>
+          <span className="glass px-4 py-1.5">Mentoria humana + IA</span>
+        </div>
 
         {/* Seta */}
         <a
           href="#como-funciona"
           onClick={handleGoToHowItWorks}
-          className="group mt-6 sm:mt-8 inline-flex cursor-pointer select-none"
+          className="group mt-10 inline-flex cursor-pointer select-none rounded-full border border-transparent p-3 text-[#6B7280] transition duration-300 ease-out hover:text-[#4F46E5] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           aria-label="Ir para a próxima seção"
         >
-          <ChevronDown className="h-5 w-5 sm:h-6 sm:w-6 text-zinc-400 group-hover:text-zinc-600 transition-colors" />
+          <ChevronDown className="h-5 w-5 sm:h-6 sm:w-6 transition-transform duration-300 group-hover:translate-y-1" />
         </a>
       </div>
     </section>

--- a/src/sections/HowItWorksSection.tsx
+++ b/src/sections/HowItWorksSection.tsx
@@ -23,14 +23,16 @@ const HowItWorks: React.FC = () => {
   const Demo = ({ step }: { step: number }) => {
     if (step === 1)
       return (
-        <div className="space-y-3">
-          <div className="text-xs sm:text-sm text-zinc-400">Sua expressão</div>
-          <div className="bg-white rounded-xl p-4 border border-zinc-100">
-            <p className="text-zinc-800 leading-relaxed">
+        <div className="space-y-4">
+          <span className="text-xs font-medium uppercase tracking-[0.18em] text-[#A1A6BB]">
+            Sua expressão
+          </span>
+          <div className="rounded-2xl border border-white/40 bg-white/80 p-4 shadow-sm backdrop-blur-xl">
+            <p className="text-sm leading-relaxed text-[#111827]">
               Hoje me sinto confuso, tentando ouvir o que está aqui dentro.
             </p>
           </div>
-          <div className="mt-1 flex items-center h-11 rounded-xl px-4 text-zinc-400 bg-zinc-50 border border-zinc-200">
+          <div className="mt-1 flex h-11 items-center rounded-xl border border-white/30 bg-white/60 px-4 text-sm text-[#6B7280] backdrop-blur-xl">
             Dê forma ao que sente…
           </div>
         </div>
@@ -38,12 +40,12 @@ const HowItWorks: React.FC = () => {
 
     if (step === 2)
       return (
-        <div className="flex flex-col items-center justify-center py-6">
-          <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-full relative overflow-hidden border border-zinc-200 shadow-inner bg-white">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_30%,white,rgba(91,75,255,0.10)_45%,rgba(91,75,255,0.18)_80%)]" />
-            <div className="absolute inset-0 rounded-full border border-white/60 animate-pulse" />
+        <div className="flex flex-col items-center justify-center space-y-4 py-6">
+          <div className="relative flex h-28 w-28 items-center justify-center overflow-hidden rounded-full border border-white/50 bg-white/80 shadow-inner backdrop-blur-xl">
+            <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_30%_30%,rgba(255,255,255,0.9),rgba(99,102,241,0.16)_50%,rgba(79,70,229,0.22)_85%)]" />
+            <div className="absolute inset-0 rounded-full border border-white/60 opacity-70 animate-pulse" />
           </div>
-          <p className="text-center text-zinc-600 mt-4 text-sm leading-relaxed">
+          <p className="px-6 text-center text-sm leading-relaxed text-[#6B7280]">
             Uma resposta nasce do que você revela.
           </p>
         </div>
@@ -51,10 +53,12 @@ const HowItWorks: React.FC = () => {
 
     if (step === 3)
       return (
-        <div className="space-y-3">
-          <div className="text-xs sm:text-sm text-zinc-400">Seu insight</div>
-          <div className="bg-gradient-to-br from-[#5B4BFF]/10 to-[#5B4BFF]/5 rounded-xl p-4 border border-zinc-200">
-            <p className="text-zinc-800 leading-relaxed">
+        <div className="space-y-4">
+          <span className="text-xs font-medium uppercase tracking-[0.18em] text-[#A1A6BB]">
+            Seu insight
+          </span>
+          <div className="rounded-2xl border border-[#C7D2FE]/60 bg-gradient-to-br from-[#E0E7FF]/60 via-white to-[#F5F3FF]/70 p-4 shadow-sm backdrop-blur-xl">
+            <p className="text-sm leading-relaxed text-[#111827]">
               O que se repete começa a ganhar contorno.
             </p>
           </div>
@@ -62,18 +66,20 @@ const HowItWorks: React.FC = () => {
       );
 
     return (
-      <div className="space-y-3">
-        <div className="text-xs sm:text-sm text-zinc-400">Memória (exemplo)</div>
-        <div className="bg-white rounded-xl p-4 border border-zinc-200 max-h-[240px] overflow-y-auto space-y-4">
-          <div className="border-b border-zinc-200 pb-3">
-            <div className="text-xs text-zinc-400">14 de julho</div>
-            <p className="text-zinc-800 text-sm leading-relaxed">
+      <div className="space-y-4">
+        <span className="text-xs font-medium uppercase tracking-[0.18em] text-[#A1A6BB]">
+          Memória (exemplo)
+        </span>
+        <div className="max-h-[240px] space-y-4 overflow-y-auto rounded-2xl border border-white/40 bg-white/80 p-4 shadow-sm backdrop-blur-xl">
+          <div className="border-b border-white/40 pb-3">
+            <div className="text-xs text-[#A1A6BB]">14 de julho</div>
+            <p className="text-sm leading-relaxed text-[#111827]">
               Hoje me senti mais presente e calmo.
             </p>
           </div>
-          <div className="border-b border-zinc-200 pb-3">
-            <div className="text-xs text-zinc-400">12 de julho</div>
-            <p className="text-zinc-800 text-sm leading-relaxed">
+          <div className="border-b border-white/40 pb-3">
+            <div className="text-xs text-[#A1A6BB]">12 de julho</div>
+            <p className="text-sm leading-relaxed text-[#111827]">
               Notei que estou reconhecendo melhor o que sinto.
             </p>
           </div>
@@ -86,75 +92,80 @@ const HowItWorks: React.FC = () => {
     <section
       id="como-funciona"
       ref={ref}
-      className="py-20 sm:py-24 px-4 sm:px-6 bg-[#F7F6FB] w-full flex flex-col items-center scroll-mt-24"
+      className="relative w-full scroll-mt-24 bg-white py-20 md:py-28"
     >
+      <div className="pointer-events-none absolute left-[12%] top-12 hidden h-64 w-64 -translate-x-1/2 rounded-full bg-gradient-to-br from-purple-200 via-transparent to-indigo-200 opacity-40 blur-3xl lg:block" aria-hidden />
+
       {/* Cabeçalho estilo “continuação” */}
       <div
-        className={`w-full max-w-7xl mx-auto mb-10 sm:mb-14 transition-all duration-700 ease-out ${
+        className={`mx-auto mb-12 flex w-full max-w-7xl flex-col px-4 sm:px-6 lg:px-8 transition-all duration-700 ease-out ${
           isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
         }`}
       >
-        <h2 className="text-left heading-lg font-semibold">
-          <span className="text-zinc-900">Como a Eco</span>
-          {" "}
-          <span className="bg-gradient-to-r from-[#9B8CFF] to-[#7C5CFF] bg-clip-text text-transparent">
-            funciona.
-          </span>
+        <h2 className="heading-lg text-left font-semibold text-[#111827]">
+          Como a Eco acompanha sua clareza emocional.
         </h2>
-        <p className="mt-2 subheading text-left text-zinc-500">
-          Os passos. Do primeiro registro à clareza.
+        <p className="subheading mt-3 max-w-2xl text-left text-[#6B7280]">
+          Passo a passo, da escrita à leitura delicada dos seus padrões.
         </p>
       </div>
 
       {/* MOBILE: cards empilhados + demo inline no card ativo */}
-      <div className="w-full max-w-3xl lg:hidden space-y-4">
+      <div className="w-full max-w-3xl space-y-4 px-4 sm:px-6 lg:hidden">
         {steps.map((step) => {
           const Icon = step.icon;
           const active = activeStep === step.id;
           return (
             <div
               key={step.id}
-              className={`w-full text-left rounded-2xl border transition-all
-                ${active ? "border-[#E6E1F9] ring-2 ring-[#7C5CFF]/15 bg-white" : "border-zinc-100 bg-white"}
-                hover:border-zinc-200 hover:translate-y-[1px] active:scale-[0.995]`}
+              className={`glass glass-hover w-full transition-all duration-300 ease-out ${
+                active
+                  ? "border-white/50 bg-white/70 ring-2 ring-[#A78BFA]/40 shadow-md"
+                  : "border-white/30 bg-white/50"
+              }`}
             >
               <button
                 onClick={() => setActiveStep(active ? 0 : step.id)}
-                className="w-full flex items-center gap-4 p-4"
+                className="flex w-full items-center gap-4 rounded-[inherit] px-5 py-5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                 aria-expanded={active}
                 aria-pressed={active}
                 aria-controls={`demo-${step.id}`}
               >
-                <div
-                  className={`flex items-center justify-center w-12 h-12 rounded-full
-                    border border-white/60 shadow-inner
-                    bg-[radial-gradient(circle_at_30%_30%,white,rgba(91,75,255,0.08)_45%,rgba(91,75,255,0.14)_80%)]
-                    ${active ? "" : "opacity-90"}`}
+                <span
+                  className={`flex h-12 w-12 items-center justify-center rounded-full border border-white/60 bg-gradient-to-br from-white via-white/60 to-[#E0E7FF]/70 shadow-inner transition-opacity duration-300 ease-out ${
+                    active ? "opacity-100" : "opacity-90"
+                  }`}
                   aria-hidden
                 >
-                  <Icon size={18} strokeWidth={1.6} className="text-zinc-700" />
-                </div>
+                  <Icon size={18} strokeWidth={1.6} className="text-[#4F46E5]" />
+                </span>
 
-                <div className="flex-1">
-                  <div className="flex items-baseline gap-2">
-                    <h3 className="text-[16px] text-zinc-900 font-medium leading-snug">{step.title}</h3>
-                    <span className="ml-auto text-[12px] text-zinc-400 tabular-nums">0{step.id}</span>
-                  </div>
-                  <p className="text-zinc-600 text-[13px] leading-snug line-clamp-2">{step.description}</p>
+                <span className="flex flex-1 flex-col gap-2">
+                  <span className="flex items-baseline gap-2">
+                    <span className="text-sm font-semibold leading-snug text-[#111827] sm:text-[16px]">
+                      {step.title}
+                    </span>
+                    <span className="ml-auto text-[12px] font-medium text-[#A1A6BB] tabular-nums">
+                      0{step.id}
+                    </span>
+                  </span>
+                  <span className="text-[13px] leading-snug text-[#6B7280] sm:text-[14px]">
+                    {step.description}
+                  </span>
                   {step.id === 4 && (
                     <a
                       href="#relatorio"
-                      className="mt-2 inline-flex items-center text-[13px] text-zinc-600 hover:text-zinc-800"
+                      className="mt-1 inline-flex items-center text-[13px] font-semibold text-[#4F46E5] transition-colors duration-200 ease-out hover:text-[#111827] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                     >
                       Ver relatório emocional →
                     </a>
                   )}
-                </div>
+                </span>
               </button>
 
               {active && (
-                <div id={`demo-${step.id}`} className="px-4 pb-4 scroll-mt-24">
-                  <div className="mt-1 rounded-xl border border-zinc-100 bg-white p-4">
+                <div id={`demo-${step.id}`} className="px-5 pb-5">
+                  <div className="rounded-2xl border border-white/40 bg-white/75 p-4 shadow-sm backdrop-blur-xl">
                     <Demo step={step.id} />
                   </div>
                 </div>
@@ -165,7 +176,7 @@ const HowItWorks: React.FC = () => {
       </div>
 
       {/* DESKTOP: lista à esquerda + demo fixa à direita */}
-      <div className="w-full max-w-7xl hidden lg:grid grid-cols-2 gap-12 items-start text-left">
+      <div className="mx-auto hidden w-full max-w-7xl grid-cols-2 gap-12 px-4 sm:px-6 lg:px-8 lg:grid">
         <div className="space-y-4">
           {steps.map((step) => {
             const Icon = step.icon;
@@ -174,42 +185,48 @@ const HowItWorks: React.FC = () => {
               <button
                 key={step.id}
                 onClick={() => setActiveStep(step.id)}
-                className={`w-full flex items-center gap-4 px-5 py-4 rounded-2xl transition-all border bg-white
-                  ${active ? "border-[#E6E1F9] ring-2 ring-[#7C5CFF]/15" : "border-zinc-100"}
-                  hover:border-zinc-200 hover:translate-y-[1px] active:scale-[0.995]`}
+                className={`glass glass-hover flex w-full items-center gap-4 rounded-2xl px-6 py-5 text-left transition-all duration-300 ease-out ${
+                  active
+                    ? "border-white/60 bg-white/70 ring-2 ring-[#A78BFA]/40 shadow-md"
+                    : "border-white/30 bg-white/40"
+                }`}
                 aria-pressed={active}
                 aria-controls={`demo-desktop-${step.id}`}
               >
-                <div
-                  className={`flex items-center justify-center w-12 h-12 rounded-full
-                    border border-white/60 shadow-inner
-                    bg-[radial-gradient(circle_at_30%_30%,white,rgba(91,75,255,0.08)_45%,rgba(91,75,255,0.14)_80%)]`}
+                <span
+                  className="flex h-12 w-12 items-center justify-center rounded-full border border-white/60 bg-gradient-to-br from-white via-white/60 to-[#E0E7FF]/70 shadow-inner"
                   aria-hidden
                 >
-                  <Icon size={18} strokeWidth={1.6} className="text-zinc-700" />
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-baseline gap-2">
-                    <h3 className="text-[17px] text-zinc-900 font-medium leading-snug">{step.title}</h3>
-                    <span className="ml-auto text-[12px] text-zinc-400 tabular-nums">0{step.id}</span>
-                  </div>
-                  <p className="text-zinc-600 text-[15px] leading-snug">{step.description}</p>
+                  <Icon size={18} strokeWidth={1.6} className="text-[#4F46E5]" />
+                </span>
+                <span className="flex flex-1 flex-col gap-2">
+                  <span className="flex items-baseline gap-2">
+                    <span className="text-[17px] font-semibold leading-snug text-[#111827]">
+                      {step.title}
+                    </span>
+                    <span className="ml-auto text-xs font-medium text-[#A1A6BB] tabular-nums">
+                      0{step.id}
+                    </span>
+                  </span>
+                  <span className="text-[15px] leading-snug text-[#6B7280]">
+                    {step.description}
+                  </span>
                   {step.id === 4 && (
                     <a
                       href="#relatorio"
-                      className="mt-2 inline-flex items-center text-[13px] text-zinc-600 hover:text-zinc-800"
+                      className="mt-1 inline-flex items-center text-[13px] font-semibold text-[#4F46E5] transition-colors duration-200 ease-out hover:text-[#111827] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                     >
                       Ver relatório emocional →
                     </a>
                   )}
-                </div>
+                </span>
               </button>
             );
           })}
         </div>
 
-        <div className="relative bg-white/70 backdrop-blur-xl rounded-3xl border border-white p-8 min-h-[420px] overflow-hidden">
-          <div className="absolute inset-0 bg-[radial-gradient(120%_80%_at_70%_0%,rgba(91,75,255,0.06),transparent)] pointer-events-none" />
+        <div className="glass relative min-h-[420px] overflow-hidden rounded-3xl border-white/40 bg-white/60 p-8 shadow-lg">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_80%_at_70%_0%,rgba(99,102,241,0.12),transparent)]" />
           <div className="relative h-full" id="demo-desktop">
             <Demo step={activeStep || 1} />
           </div>


### PR DESCRIPTION
## Summary
- adopt SF Pro type system and add reusable glass/liquid utility classes for translucent Apple-inspired surfaces
- refresh the hero with gradient backdrops, accent CTAs, and social proof chips using the new glassmorphism tokens
- restyle the How It Works cards with glass panels, fluid hover states, and updated demo visuals for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93c95aefc83259736bd89133b0322