### PR TITLE
Implement IntersectionObserver-based reveal animations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import CallToActionEco from './sections/CallToActionEco';
 import Testimonials from './sections/Testimonials';
 
 import ReflexaoPage from './pages/ReflexaoPage';
+import useReveal from './hooks/useReveal';
 
 const LandingPage: React.FC = () => {
   return (
@@ -43,6 +44,8 @@ const LandingPage: React.FC = () => {
 };
 
 const App: React.FC = () => {
+  useReveal();
+
   return (
     <Router>
       <Routes>

--- a/src/components/Reveal.tsx
+++ b/src/components/Reveal.tsx
@@ -1,0 +1,53 @@
+import type {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ElementType,
+  ReactNode,
+} from "react";
+
+type RevealProps<T extends ElementType> = {
+  as?: T;
+  children: ReactNode;
+  className?: string;
+  index?: number;
+  delayIncrement?: number;
+  delayOffset?: number;
+  duration?: number;
+  ease?: string;
+  style?: CSSProperties;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "className" | "style">;
+
+const DEFAULT_EASE = "cubic-bezier(0.16, 1, 0.3, 1)";
+
+const Reveal = <T extends ElementType = "div">({
+  as,
+  children,
+  className = "",
+  index = 0,
+  delayIncrement = 90,
+  delayOffset = 0,
+  duration = 820,
+  ease = DEFAULT_EASE,
+  style,
+  ...rest
+}: RevealProps<T>) => {
+  const Component = (as ?? "div") as ElementType;
+  const computedDelay = Math.max(0, delayOffset + index * delayIncrement);
+
+  return (
+    <Component
+      className={`reveal transition-all duration-700 ease-out will-change-[opacity,transform] ${className}`.trim()}
+      style={{
+        transitionDelay: `${computedDelay}ms`,
+        transitionDuration: `${duration}ms`,
+        transitionTimingFunction: ease,
+        ...style,
+      }}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+};
+
+export default Reveal;

--- a/src/hooks/useReveal.ts
+++ b/src/hooks/useReveal.ts
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+
+const REVEAL_SELECTOR = ".reveal";
+
+export const useReveal = () => {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const reduceQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const observed = new Set<Element>();
+
+    const makeVisible = (elements: Iterable<Element>) => {
+      for (const el of elements) {
+        (el as HTMLElement).classList.add("reveal-visible");
+      }
+    };
+
+    const root = document.body;
+    if (!root) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("reveal-visible");
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      {
+        rootMargin: "0px 0px -10%",
+        threshold: 0.15,
+      }
+    );
+
+    const registerElements = () => {
+      const elements = document.querySelectorAll(REVEAL_SELECTOR);
+      if (reduceQuery.matches) {
+        makeVisible(elements);
+        return;
+      }
+
+      elements.forEach((element) => {
+        if (!observed.has(element)) {
+          observed.add(element);
+          element.classList.remove("reveal-visible");
+          observer.observe(element);
+        }
+      });
+    };
+
+    const mutationObserver = new MutationObserver(() => {
+      registerElements();
+    });
+
+    if (!reduceQuery.matches) {
+      registerElements();
+    } else {
+      makeVisible(document.querySelectorAll(REVEAL_SELECTOR));
+    }
+
+    mutationObserver.observe(root, {
+      childList: true,
+      subtree: true,
+    });
+
+    const handlePreferenceChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        makeVisible(document.querySelectorAll(REVEAL_SELECTOR));
+        observer.disconnect();
+        observed.clear();
+      } else {
+        registerElements();
+      }
+    };
+
+    if (typeof reduceQuery.addEventListener === "function") {
+      reduceQuery.addEventListener("change", handlePreferenceChange);
+    } else {
+      // Safari < 14 fallback
+      // @ts-expect-error -- addListener is legacy but still needed for some browsers
+      reduceQuery.addListener(handlePreferenceChange);
+    }
+
+    return () => {
+      if (typeof reduceQuery.removeEventListener === "function") {
+        reduceQuery.removeEventListener("change", handlePreferenceChange);
+      } else {
+        // @ts-expect-error -- removeListener is legacy but still needed for some browsers
+        reduceQuery.removeListener(handlePreferenceChange);
+      }
+      mutationObserver.disconnect();
+      observer.disconnect();
+      observed.clear();
+    };
+  }, []);
+};
+
+export default useReveal;

--- a/src/index.css
+++ b/src/index.css
@@ -166,3 +166,23 @@ section { scroll-snap-align: start; }
     letter-spacing: -0.01em;
   }
 }
+
+.reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  will-change: opacity, transform;
+}
+
+.reveal-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .reveal-visible {
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -1,11 +1,9 @@
 import React from "react"; 
 import { ChevronDown, ChevronRight, PlayCircle } from "lucide-react";
 import Orb from "../components/Orb";
-import { useScrollReveal } from "../hooks/useScrollReveal";
+import Reveal from "../components/Reveal";
 
 const HeroSection: React.FC = () => {
-  const { ref, isVisible } = useScrollReveal();
-
   const handleGoToHowItWorks = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     const el = document.getElementById("como-funciona");
@@ -14,7 +12,6 @@ const HeroSection: React.FC = () => {
 
   return (
     <section
-      ref={ref}
       aria-labelledby="hero-title"
       className={`
         relative overflow-hidden liquid-bg
@@ -48,64 +45,91 @@ const HeroSection: React.FC = () => {
           md:pt-[calc(var(--nav-h,80px)+88px)]
           pb-[calc(32px+env(safe-area-inset-bottom))]
           md:pb-32
-          transition-all duration-500 ease-out
-          ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}
-          transform-gpu will-change-[opacity,transform]
         `}
       >
         {/* Pílula */}
-        <span className="glass inline-flex items-center gap-2 rounded-full px-5 py-2 text-xs font-medium uppercase tracking-[0.2em] text-[#6B7280]">
+        <Reveal
+          as="span"
+          index={0}
+          duration={820}
+          className="glass inline-flex items-center gap-2 rounded-full px-5 py-2 text-xs font-medium uppercase tracking-[0.2em] text-[#6B7280]"
+        >
           Jornada de autoconhecimento
-        </span>
+        </Reveal>
 
         {/* Título */}
-        <h1 id="hero-title" className="heading-xl mt-8 text-balance font-semibold text-[#111827]">
+        <Reveal
+          as="h1"
+          index={1}
+          duration={880}
+          className="heading-xl mt-8 text-balance font-semibold text-[#111827]"
+          id="hero-title"
+        >
           Eco, um espaço delicado para ler o que você sente.
-        </h1>
+        </Reveal>
 
         {/* Subtítulo */}
-        <p className="subheading mt-6 max-w-2xl text-balance text-[#6B7280]">
+        <Reveal
+          as="p"
+          index={2}
+          duration={900}
+          className="subheading mt-6 max-w-2xl text-balance text-[#6B7280]"
+        >
           Um diário inteligente com toques humanos: escreva, receba reflexões e acompanhe sua evolução emocional com suavidade.
-        </p>
+        </Reveal>
 
         {/* CTAs */}
         <div className="mt-10 flex w-full flex-col items-center justify-center gap-4 sm:mt-12 sm:flex-row sm:flex-wrap md:flex-nowrap md:gap-5">
-          <a
+          <Reveal
+            as="a"
             href="https://ecofrontend888.vercel.app/login"
             aria-label="Começar minha jornada"
+            index={3}
+            duration={960}
             className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#4F46E5] to-[#6366F1] px-8 py-3 text-base font-semibold text-white shadow-[0_18px_36px_rgba(99,102,241,0.28)] transition duration-300 ease-out hover:shadow-[0_22px_44px_rgba(99,102,241,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
           >
             <PlayCircle size={18} className="opacity-90" />
             Começar minha jornada
-          </a>
+          </Reveal>
 
-          <a
+          <Reveal
+            as="a"
             href="#como-funciona"
             onClick={handleGoToHowItWorks}
+            index={4}
+            duration={960}
             className="group inline-flex w-full items-center justify-center gap-2 rounded-full border border-[#E0E7FF] bg-white/80 px-8 py-3 text-base font-semibold text-[#4F46E5] shadow-sm transition duration-300 ease-out hover:border-[#C7D2FE] hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
             aria-label="Ver como funciona"
           >
             Ver como funciona
             <ChevronRight size={18} className="transition-transform duration-300 group-hover:translate-x-1" />
-          </a>
+          </Reveal>
         </div>
 
         {/* Micro-confiança */}
-        <div className="mt-10 flex flex-wrap justify-center gap-3 text-xs font-medium text-[#6B7280] sm:text-sm">
+        <Reveal
+          as="div"
+          index={5}
+          duration={920}
+          className="mt-10 flex flex-wrap justify-center gap-3 text-xs font-medium text-[#6B7280] sm:text-sm"
+        >
           <span className="glass px-4 py-1.5">Beta gratuito</span>
           <span className="glass px-4 py-1.5">Relatórios emocionais guiados</span>
           <span className="glass px-4 py-1.5">Mentoria humana + IA</span>
-        </div>
+        </Reveal>
 
         {/* Seta */}
-        <a
+        <Reveal
+          as="a"
           href="#como-funciona"
           onClick={handleGoToHowItWorks}
+          index={6}
+          duration={900}
           className="group mt-10 inline-flex cursor-pointer select-none rounded-full border border-transparent p-3 text-[#6B7280] transition duration-300 ease-out hover:text-[#4F46E5] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           aria-label="Ir para a próxima seção"
         >
           <ChevronDown className="h-5 w-5 sm:h-6 sm:w-6 transition-transform duration-300 group-hover:translate-y-1" />
-        </a>
+        </Reveal>
       </div>
     </section>
   );

--- a/src/sections/MentoresStrip.tsx
+++ b/src/sections/MentoresStrip.tsx
@@ -7,6 +7,7 @@ import nassim  from "@/assets/mentores/nassim-taleb.png";
 import brene   from "@/assets/mentores/brene-brown.png";
 import joe     from "@/assets/mentores/joe-dispenza.png";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import Reveal from "../components/Reveal";
 
 type Mentor = {
   name: string;
@@ -103,20 +104,36 @@ const MentoresStrip: React.FC = () => {
       <div className="relative z-10 mx-auto max-w-7xl px-5">
         {/* Título + mensagem de valor */}
         <div className="text-center mb-8 sm:mb-12">
-          <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs sm:text-sm font-medium text-white/90 bg-white/10 border border-white/20 backdrop-blur">
+          <Reveal
+            as="span"
+            index={0}
+            duration={780}
+            className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs sm:text-sm font-medium text-white/90 bg-white/10 border border-white/20 backdrop-blur"
+          >
             Referências • Base das respostas
-          </span>
+          </Reveal>
 
-          <h2 id="mentores-title" className="mt-4 heading-lg font-semibold text-white">
+          <Reveal
+            as="h2"
+            index={1}
+            duration={860}
+            className="mt-4 heading-lg font-semibold text-white"
+            id="mentores-title"
+          >
             <span className="text-white">Grandes mentes.</span>
             <span className="text-white/70"> As ideias que inspiram a Eco.</span>
-          </h2>
+          </Reveal>
 
-          <p className="text-white/90 max-w-2xl mx-auto mt-3 text-sm sm:text-base">
+          <Reveal
+            as="p"
+            index={2}
+            duration={900}
+            className="text-white/90 max-w-2xl mx-auto mt-3 text-sm sm:text-base"
+          >
             A Eco não dá respostas genéricas: usa princípios de <span className="font-medium">filosofia</span>,{" "}
             <span className="font-medium">psicologia</span> e <span className="font-medium">ciência</span> para orientar reflexões
             mais humanas, profundas e confiáveis.
-          </p>
+          </Reveal>
         </div>
 
         {/* SETAS mobile */}
@@ -157,8 +174,12 @@ const MentoresStrip: React.FC = () => {
           "
         >
           {MENTORES.map((m, index) => (
-            <figure
+            <Reveal
+              as="figure"
               key={m.name}
+              index={index}
+              delayOffset={160}
+              duration={860}
               className="snap-center shrink-0 w-[240px] sm:w-[260px] md:w-auto md:shrink md:snap-none group"
             >
               <div
@@ -198,12 +219,15 @@ const MentoresStrip: React.FC = () => {
                   </p>
                 </figcaption>
               </div>
-            </figure>
+            </Reveal>
           ))}
         </div>
 
         {/* HINT mobile */}
-        <p
+        <Reveal
+          as="p"
+          index={MENTORES.length + 1}
+          duration={780}
           className="md:hidden mx-auto mt-5 inline-flex items-center gap-2 px-3 py-1 rounded-full
                       bg-white/10 text-[11.5px] text-white/90 backdrop-blur-sm border border-white/20"
         >
@@ -217,10 +241,13 @@ const MentoresStrip: React.FC = () => {
           >
             <path d="M9 18l6-6-6-6" />
           </svg>
-        </p>
+        </Reveal>
 
         {/* Caixinha de explicação — “Como a Eco usa isso” */}
-        <div
+        <Reveal
+          as="div"
+          index={MENTORES.length + 2}
+          duration={880}
           className="
             mt-8 sm:mt-10 rounded-2xl px-4 sm:px-6 py-4 sm:py-5
             bg-white/10 text-white/90 backdrop-blur border border-white/20
@@ -240,7 +267,7 @@ const MentoresStrip: React.FC = () => {
               <span className="font-medium">Micro-ações práticas</span> (antifragilidade & neurociência) para transformar insight em mudança real.
             </li>
           </ul>
-        </div>
+        </Reveal>
       </div>
 
       <style>{`


### PR DESCRIPTION
## Summary
- add a reusable `useReveal` hook to observe `.reveal` elements with IntersectionObserver and respect reduced-motion preferences
- create a configurable `Reveal` component and Tailwind utility styles for reveal transitions
- apply staggered reveal animations to hero content and mentor cards while wiring the hook at the app level

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9434c9bd083258e160c517ccdfa88