### PR TITLE
Refine landing page with minimalist glassmorphism styling

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,130 +1,77 @@
 import React from "react";
-import { MessageSquare, Shield, Heart } from "lucide-react";
+import { MessageSquare, ShieldCheck, Sparkles } from "lucide-react";
+
+const utilityLinks = [
+  { icon: MessageSquare, label: "Fale com a Eco", href: "#" },
+  { icon: ShieldCheck, label: "Privacidade & termos", href: "#" },
+  { icon: Sparkles, label: "Nosso propósito", href: "#" },
+];
+
+const socials = [
+  { label: "Instagram", href: "#", d: "M7 2C4.2 2 2 4.2 2 7v10c0 2.8 2.2 5 5 5h10c2.8 0 5-2.2 5-5V7c0-2.8-2.2-5-5-5H7zm10 2c1.7 0 3 1.3 3 3v10c0 1.7-1.3 3-3 3H7c-1.7 0-3-1.3-3-3V7c0-1.7 1.3-3 3-3h10zm-5 3a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm0 2.2a2.8 2.8 0 1 1 0 5.6 2.8 2.8 0 0 1 0-5.6zm4.4-.9a1 1 0 1 1 0 2 1 1 0 0 1 0-2z" },
+  { label: "LinkedIn", href: "#", d: "M4.98 3.5a2.5 2.5 0 1 1 0 5.001 2.5 2.5 0 0 1 0-5zM3 9h3.96v12H3zM10.5 9H14v1.8h.06c.48-.9 1.64-1.86 3.38-1.86 3.62 0 4.29 2.38 4.29 5.47V21H17.7v-5.4c0-1.29-.03-2.95-1.8-2.95-1.81 0-2.09 1.41-2.09 2.86V21H10.5z" },
+  { label: "YouTube", href: "#", d: "M10 7l6 4-6 4zM21.8 6.2a3 3 0 0 0-2.1-2.1C17.8 3.5 12 3.5 12 3.5s-5.8 0-7.7.6a3 3 0 0 0-2.1 2.1C1.5 8.1 1.5 12 1.5 12s0 3.9.7 5.8a3 3 0 0 0 2.1 2.1c1.9.6 7.7.6 7.7.6s5.8 0 7.7-.6a3 3 0 0 0 2.1-2.1c.6-1.9.6-5.8.6-5.8s0-3.9-.6-5.8z" },
+];
+
+const columns = [
+  { title: "Produto", items: ["Versão beta", "Funcionalidades", "Roadmap", "Preços"] },
+  { title: "Suporte", items: ["Central de ajuda", "Contato", "Guia rápido", "Tutoriais"] },
+  { title: "Empresa", items: ["Sobre", "Blog", "Carreiras", "Imprensa"] },
+];
 
 const Footer: React.FC = () => {
-  const socials = [
-    {
-      label: "Twitter",
-      href: "#",
-      d: "M23 3a10.9 10.9 0 0 1-3.14 1.53A4.48 4.48 0 0 0 22.4 1.64a9.09 9.09 0 0 1-2.88 1.1A4.52 4.52 0 0 0 16.6 0c-2.5 0-4.51 2.28-3.95 4.7A12.94 12.94 0 0 1 3 1.6a4.48 4.48 0 0 0-.61 2.27c0 1.57.8 2.96 2 3.77a4.48 4.48 0 0 1-2-.55v.06a4.53 4.53 0 0 0 3.6 4.44 4.52 4.52 0 0 1-2 .08 4.5 4.5 0 0 0 4.2 3.13A9.06 9.06 0 0 1 1 19.54a12.8 12.8 0 0 0 7 2.05c8.38 0 12.96-7.43 12.67-14.1A9.18 9.18 0 0 0 23 3z",
-    },
-    {
-      label: "GitHub",
-      href: "#",
-      d: "M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.11.82-.26.82-.577v-2.02c-3.338.725-4.033-1.61-4.033-1.61-.546-1.39-1.333-1.76-1.333-1.76-1.09-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.834 2.81 1.304 3.495.997.107-.776.418-1.305.76-1.605-2.665-.3-5.467-1.33-5.467-5.933 0-1.31.465-2.38 1.235-3.22-.135-.3-.54-1.52.105-3.165 0 0 1.005-.322 3.3 1.23a11.48 11.48 0 0 1 3-.405c1.02.005 2.045.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.645.24 2.865.12 3.165.765.84 1.23 1.91 1.23 3.22 0 4.615-2.805 5.63-5.475 5.92.435.375.81 1.11.81 2.24v3.32c0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z",
-    },
-    {
-      label: "YouTube",
-      href: "#",
-      d: "M19.615 3.184C21.165 3.66 22.34 4.83 22.82 6.385 23.75 9.255 23.75 12 23.75 12s0 2.745-.93 5.615c-.48 1.555-1.655 2.725-3.205 3.2-2.87.93-9.615.93-9.615.93s-6.745 0-9.615-.93C1.655 20.34.48 19.17 0 17.615-.93 14.745-.93 12-.93 12s0-2.745.93-5.615C1.41 4.83 2.585 3.66 4.135 3.185 7.005 2.255 13.75 2.255 13.75 2.255s6.745 0 9.615.93zM9.75 15.5V8.5l6.25 3.5-6.25 3.5z",
-    },
-  ];
-
-  const columns = [
-    { title: "Produto", items: ["Versão Beta", "Funcionalidades", "Roadmap", "Preços"] },
-    { title: "Suporte", items: ["FAQ", "Contato", "Documentação", "Tutoriais"] },
-    { title: "Empresa", items: ["Sobre nós", "Blog", "Carreiras", "Imprensa"] },
-  ];
-
   return (
-    <footer
-      className="
-        relative overflow-hidden
-        bg-white
-        border-t border-slate-200/60
-        px-6 pt-16 pb-10
-      "
-    >
-      {/* light halo no topo */}
+    <footer className="relative overflow-hidden border-t border-white/60 bg-[#F9FAFB] px-6 pb-12 pt-16">
       <div aria-hidden className="pointer-events-none absolute inset-0">
-        <div className="absolute -top-20 left-1/2 -translate-x-1/2 w-[90vw] max-w-[1000px] h-[160px] rounded-full blur-[80px] bg-[radial-gradient(60%_80%_at_50%_0%,#EAE9FF_0%,transparent_70%)]" />
+        <div className="absolute inset-x-0 top-0 mx-auto h-40 max-w-5xl rounded-full bg-[radial-gradient(60%_80%_at_50%_0%,rgba(148,163,184,0.18),transparent_72%)]" />
       </div>
 
-      <div className="relative max-w-7xl mx-auto">
-        {/* faixa de utilidades (suporte/privacidade/missão) */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-10">
-          {[
-            {
-              icon: MessageSquare,
-              label: "Fale com a Eco",
-              href: "#",
-            },
-            {
-              icon: Shield,
-              label: "Privacidade e termos",
-              href: "#",
-            },
-            {
-              icon: Heart,
-              label: "Nosso propósito",
-              href: "#",
-            },
-          ].map(({ icon: Icon, label, href }) => (
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {utilityLinks.map(({ icon: Icon, label, href }) => (
             <a
               key={label}
               href={href}
-              className="
-                group inline-flex items-center justify-center gap-2
-                rounded-full h-10 px-4
-                bg-white/80 backdrop-blur
-                ring-1 ring-slate-200 hover:ring-slate-300
-                text-slate-700 hover:text-slate-900
-                transition
-              "
+              className="glass glass-hover inline-flex h-12 items-center justify-center gap-2 rounded-full px-5 text-sm font-medium text-[#6B7280]"
             >
-              <Icon size={16} className="opacity-70 group-hover:opacity-100" />
-              <span className="text-sm font-medium">{label}</span>
+              <Icon size={16} className="text-[#3B82F6]" />
+              <span>{label}</span>
             </a>
           ))}
         </div>
 
-        <div className="flex flex-col md:flex-row justify-between gap-12 md:gap-8 mb-14">
-          {/* Marca + descrição + redes */}
-          <div className="md:max-w-sm">
-            <div className="flex items-center mb-4">
-              <div className="mr-2 grid place-items-center">
-                <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[#7C5CFF] to-[#5B4BFF] p-[2px]">
-                  <div className="w-full h-full rounded-full bg-white/90 grid place-items-center">
-                    <div className="w-3.5 h-3.5 rounded-full bg-gradient-to-br from-[#7C5CFF] to-[#5B4BFF]" />
-                  </div>
-                </div>
-              </div>
-              <span className="text-xl tracking-tight text-slate-900">eco</span>
+        <div className="flex flex-col gap-12 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-md space-y-6">
+            <div className="flex items-center gap-3">
+              <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/60 bg-white/80 shadow-[0_8px_32px_rgba(15,23,42,0.08)]">
+                <span className="text-[18px] font-semibold tracking-tight text-[#3B82F6]">E</span>
+              </span>
+              <span className="text-2xl font-semibold tracking-tight text-[#111827]">eco</span>
             </div>
-
-            <p className="text-sm leading-relaxed text-slate-600">
-              Inteligência emocional que entende a essência por trás das suas palavras.
+            <p className="text-sm leading-relaxed text-[#6B7280]">
+              Inteligência emocional que te devolve para dentro, com delicadeza e clareza em cada conversa.
             </p>
-
-            <div className="mt-5 flex items-center gap-2">
-              {socials.map((s) => (
+            <div className="flex items-center gap-3">
+              {socials.map((item) => (
                 <a
-                  key={s.label}
-                  href={s.href}
-                  aria-label={s.label}
-                  className="
-                    h-9 w-9 rounded-full
-                    bg-white text-slate-500
-                    ring-1 ring-slate-200
-                    grid place-items-center
-                    hover:text-slate-900 hover:ring-slate-300
-                    transition
-                  "
+                  key={item.label}
+                  href={item.href}
+                  aria-label={item.label}
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/60 bg-white/70 text-[#6B7280] shadow-[0_6px_20px_rgba(15,23,42,0.06)] transition hover:text-[#111827]"
                 >
-                  <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="currentColor">
-                    <path d={s.d} />
+                  <svg className="h-[18px] w-[18px]" viewBox="0 0 24 24" fill="currentColor">
+                    <path d={item.d} />
                   </svg>
                 </a>
               ))}
             </div>
           </div>
 
-          {/* Navegação */}
           <nav aria-label="Rodapé" className="flex-1">
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-10">
+            <div className="grid grid-cols-2 gap-10 md:grid-cols-3">
               {columns.map((col) => (
-                <div key={col.title}>
-                  <h3 className="text-[12px] font-medium uppercase tracking-wider text-slate-500 mb-3">
+                <div key={col.title} className="space-y-3">
+                  <h3 className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[#6B7280]">
                     {col.title}
                   </h3>
                   <ul className="space-y-2.5">
@@ -132,10 +79,7 @@ const Footer: React.FC = () => {
                       <li key={item}>
                         <a
                           href="#"
-                          className="
-                            text-[14px] text-slate-600 hover:text-slate-900
-                            transition
-                          "
+                          className="text-[14px] font-medium text-[#4B5563] transition hover:text-[#111827]"
                         >
                           {item}
                         </a>
@@ -148,12 +92,11 @@ const Footer: React.FC = () => {
           </nav>
         </div>
 
-        {/* base inferior */}
-        <div className="border-t border-slate-200 pt-6 flex flex-col md:flex-row items-center justify-between gap-3 text-[13px] text-slate-500">
+        <div className="flex flex-col items-start gap-4 border-t border-white/60 pt-6 text-[13px] text-[#6B7280] md:flex-row md:items-center md:justify-between">
           <p>© {new Date().getFullYear()} Eco. Todos os direitos reservados.</p>
-          <div className="flex items-center gap-5">
-            {["Termos de Serviço", "Privacidade", "Cookies"].map((item) => (
-              <a key={item} href="#" className="hover:text-slate-900 transition">
+          <div className="flex flex-wrap items-center gap-4">
+            {["Termos", "Privacidade", "Cookies"].map((item) => (
+              <a key={item} href="#" className="transition hover:text-[#111827]">
                 {item}
               </a>
             ))}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,53 +23,49 @@ const Header: React.FC = () => {
 
   const isHome = location.pathname === "/";
 
-  const linkCls = scrolled
-    ? "text-neutral-800 hover:text-black"
-    : "text-white/90 hover:text-white";
+  const containerState = scrolled
+    ? "bg-white/90 shadow-[0_8px_24px_rgba(15,23,42,0.08)]"
+    : "bg-white/70 shadow-[0_12px_32px_rgba(15,23,42,0.06)]";
 
-  const ctaCls = scrolled
-    ? "bg-neutral-900 text-white hover:bg-black"
-    : "bg-white/10 text-white ring-1 ring-white/30 hover:bg-white/20";
+  const linkCls =
+    "text-[14px] font-medium text-[#6B7280] transition hover:text-[#111827]";
 
-  const iconColor = scrolled ? "text-neutral-900" : "text-white";
+  const ctaCls =
+    "inline-flex items-center gap-2 rounded-full bg-[#3B82F6] px-5 py-2 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(59,130,246,0.28)] transition hover:shadow-[0_16px_36px_rgba(59,130,246,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
 
   return (
-    <header className="fixed top-4 inset-x-0 z-50 px-4 sm:px-6 md:px-6 w-full max-w-full">
+    <header className="fixed inset-x-0 top-4 z-50 mx-auto w-full px-4 sm:px-6">
       <div
-        className={`rounded-full px-4 py-3 md:px-6 md:py-2 flex items-center justify-between border transition-all duration-700 ease-out
-        ${hasAnimated ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}
-        ${
-          scrolled
-            ? "bg-white/80 text-neutral-900 border-white/60 shadow-[0_6px_24px_rgba(0,0,0,0.12)] backdrop-blur-md"
-            : "bg-transparent text-white border-white/15 backdrop-blur-[2px]"
-        }`}
+        className={`mx-auto flex max-w-6xl items-center justify-between rounded-full border border-white/60 px-4 py-3 md:px-6 md:py-3 backdrop-blur-xl transition-all duration-500 ease-out ${
+          hasAnimated ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+        } ${containerState}`}
       >
         {/* Logo */}
         {isHome ? (
           <button
             aria-label="Voltar ao topo"
             onClick={() => scroll.scrollToTop({ duration: 500 })}
-            className={`text-lg sm:text-xl font-semibold tracking-wide transition ${iconColor}`}
+            className={`text-lg sm:text-xl font-semibold tracking-tight text-[#111827] transition`}
           >
             ECO
           </button>
         ) : (
           <RouterLink
             to="/"
-            className={`text-lg sm:text-xl font-semibold tracking-wide transition ${iconColor}`}
+            className={`text-lg sm:text-xl font-semibold tracking-tight text-[#111827] transition`}
           >
             ECO
           </RouterLink>
         )}
 
         {/* Menu Desktop */}
-        <nav className="hidden md:flex gap-8 text-sm font-medium">
+        <nav className="hidden items-center gap-8 md:flex">
           <ScrollLink
             to="como-funciona"
             smooth
             duration={500}
             offset={-80}
-            className={`cursor-pointer transition ${linkCls}`}
+            className={`cursor-pointer ${linkCls}`}
           >
             Características
           </ScrollLink>
@@ -79,7 +75,7 @@ const Header: React.FC = () => {
             smooth
             duration={500}
             offset={-80}
-            className={`cursor-pointer transition ${linkCls}`}
+            className={`cursor-pointer ${linkCls}`}
           >
             Boletim Informativo
           </ScrollLink>
@@ -89,7 +85,7 @@ const Header: React.FC = () => {
             smooth
             duration={500}
             offset={-80}
-            className={`cursor-pointer transition ${linkCls}`}
+            className={`cursor-pointer ${linkCls}`}
           >
             Opinar
           </ScrollLink>
@@ -100,7 +96,7 @@ const Header: React.FC = () => {
           href="https://ecofrontend888.vercel.app"
           target="_blank"
           rel="noopener noreferrer"
-          className={`hidden md:inline-block ml-4 rounded-full text-sm font-medium px-4 py-2 transition ${ctaCls}`}
+          className={`hidden md:inline-flex ${ctaCls}`}
         >
           Acesso Antecipado
         </a>
@@ -109,7 +105,7 @@ const Header: React.FC = () => {
         <button
           aria-label="Abrir menu"
           onClick={() => setIsMenuOpen(!isMenuOpen)}
-          className={`md:hidden p-2 ${iconColor}`}
+          className={`rounded-full p-2 text-[#6B7280] transition hover:text-[#111827] md:hidden`}
         >
           {isMenuOpen ? <X size={20} /> : <Menu size={20} />}
         </button>
@@ -118,8 +114,7 @@ const Header: React.FC = () => {
       {/* Dropdown Mobile */}
       {isMenuOpen && (
         <div
-          className={`mt-2 mx-4 md:hidden flex flex-col gap-4 rounded-2xl px-6 py-4 border shadow-lg backdrop-blur-md
-            ${scrolled ? "bg-white/90 text-neutral-900 border-white/60" : "bg-black/80 text-white border-white/20"}`}
+          className="mx-4 mt-3 flex flex-col gap-4 rounded-2xl border border-white/60 bg-white/90 px-6 py-5 text-[#111827] shadow-[0_16px_40px_rgba(15,23,42,0.08)] backdrop-blur-xl md:hidden"
         >
           <ScrollLink
             to="como-funciona"
@@ -127,7 +122,7 @@ const Header: React.FC = () => {
             duration={500}
             offset={-80}
             onClick={() => setIsMenuOpen(false)}
-            className="font-semibold cursor-pointer"
+            className="cursor-pointer text-[15px] font-medium text-[#6B7280] transition hover:text-[#111827]"
           >
             Características
           </ScrollLink>
@@ -138,7 +133,7 @@ const Header: React.FC = () => {
             duration={500}
             offset={-80}
             onClick={() => setIsMenuOpen(false)}
-            className="font-semibold cursor-pointer"
+            className="cursor-pointer text-[15px] font-medium text-[#6B7280] transition hover:text-[#111827]"
           >
             Boletim informativo
           </ScrollLink>
@@ -149,7 +144,7 @@ const Header: React.FC = () => {
             duration={500}
             offset={-80}
             onClick={() => setIsMenuOpen(false)}
-            className="font-semibold cursor-pointer"
+            className="cursor-pointer text-[15px] font-medium text-[#6B7280] transition hover:text-[#111827]"
           >
             Opinar
           </ScrollLink>
@@ -159,8 +154,7 @@ const Header: React.FC = () => {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => setIsMenuOpen(false)}
-            className={`w-fit rounded-full text-sm font-medium px-4 py-2 transition
-              ${scrolled ? "bg-neutral-900 text-white hover:bg-black" : "bg-white/10 text-white ring-1 ring-white/30 hover:bg-white/20"}`}
+            className="inline-flex w-fit items-center justify-center rounded-full bg-[#3B82F6] px-5 py-2 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(59,130,246,0.28)] transition hover:shadow-[0_16px_36px_rgba(59,130,246,0.32)]"
           >
             Acesso antecipado
           </a>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,7 +6,7 @@ interface LayoutProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-white via-purple-50 to-pink-50 font-sans text-gray-800">
+    <div className="min-h-screen bg-[#F9FAFB] text-[#111827] antialiased">
       {children}
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,8 @@ section { scroll-snap-align: start; }
     font-family: "SF Pro Text", "SF Pro Display", -apple-system,
       BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
     color: #111827;
-    background-color: #ffffff;
+    background-color: #F9FAFB;
+    line-height: 1.6;
   }
 
   h1,
@@ -125,11 +126,11 @@ section { scroll-snap-align: start; }
 
 @layer components {
   .glass {
-    @apply rounded-2xl border border-white/30 bg-white/40 backdrop-blur-xl shadow-sm;
+    @apply rounded-[16px] border border-white/50 bg-white/60 backdrop-blur-xl shadow-[0_8px_32px_rgba(15,23,42,0.08)];
   }
 
   .glass-hover {
-    @apply transform transition duration-300 ease-out hover:-translate-y-1 hover:bg-white/60 hover:shadow-lg;
+    @apply transform transition duration-300 ease-out hover:-translate-y-1 hover:bg-white/75 hover:shadow-[0_16px_40px_rgba(15,23,42,0.12)];
   }
 
   .liquid-bg {

--- a/src/pages/ReflexaoPage.tsx
+++ b/src/pages/ReflexaoPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import InputMask from 'react-input-mask';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
-import Orb from '../components/Orb';
 import { enviarFormulario } from '../lib/enviarFormulario';
 
 const AcessoAntecipadoPage: React.FC = () => {
@@ -78,33 +77,47 @@ const AcessoAntecipadoPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-black text-white pt-28 font-sans">
+    <div className="flex min-h-screen flex-col bg-[#F3F4F6] pt-28">
       <Header />
 
-      <main className="relative flex-grow px-6 py-12 flex flex-col-reverse lg:flex-row items-center justify-center">
-        <div className="absolute inset-0 -z-10 flex justify-center lg:justify-start items-start lg:items-center pointer-events-none">
-          <div className="w-[300px] h-[300px] md:w-[400px] md:h-[400px] lg:w-[500px] lg:h-[500px] opacity-40">
-            <Orb hoverIntensity={0.8} rotateOnHover={true} hue={270} forceHoverState={false} />
-          </div>
+      <main className="relative z-0 mx-auto flex w-full max-w-6xl flex-1 flex-col gap-10 px-6 pb-16 pt-12 lg:flex-row lg:items-start lg:gap-12">
+        <div className="absolute inset-0 -z-10">
+          <div className="pointer-events-none absolute right-[-10%] top-24 h-64 w-64 rounded-full bg-[radial-gradient(circle,rgba(59,130,246,0.16),transparent_68%)] blur-3xl" />
+          <div className="pointer-events-none absolute left-[-12%] top-1/3 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(16,185,129,0.12),transparent_70%)] blur-3xl" />
         </div>
 
-        <div className="relative z-10 w-full max-w-2xl bg-white/5 border border-white/10 backdrop-blur-md rounded-2xl shadow-2xl p-8">
-          <h1 className="text-3xl md:text-4xl font-extrabold text-white tracking-tight mb-4 text-center lg:text-left">
-            Convite para o Acesso Antecipado à <span className="text-indigo-400">Eco</span>
+        <section className="glass max-w-xl space-y-4 p-8 text-left">
+          <span className="inline-flex items-center rounded-full bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#6B7280]">
+            Acesso antecipado
+          </span>
+          <h1 className="text-3xl font-semibold leading-tight text-[#111827] md:text-4xl">
+            Convite para viver a experiência delicada da Eco
           </h1>
-          <p className="text-gray-300 mb-8 text-center lg:text-left leading-relaxed">
-            Ajude a construir a IA que não responde por responder — mas te devolve a si mesmo.
+          <p className="text-base text-[#6B7280]">
+            Ajude a desenhar uma companhia emocional que escuta com atenção e devolve clareza. Conte para a Eco quem é você e como deseja ser acompanhado.
           </p>
+          <div className="rounded-[16px] border border-[#D1D5DB] bg-white/80 p-5 text-sm text-[#4B5563] shadow-[0_8px_24px_rgba(15,23,42,0.05)]">
+            <p>
+              <strong className="font-semibold text-[#111827]">Como funciona:</strong> nós analisamos cada pedido com carinho. Selecione os canais pelos quais deseja ser avisado e, assim que o acesso estiver disponível, você será notificado.
+            </p>
+          </div>
+        </section>
 
+        <section className="glass flex-1 p-8">
           {enviado ? (
-            <div className="bg-green-900 text-green-200 rounded-lg p-6 text-center">
-              ✅ Pronto! Recebemos seu pedido. Assim que o acesso antecipado estiver disponível, você será notificado por e-mail.
+            <div className="rounded-[16px] border border-[#BBF7D0] bg-[#ECFDF5] px-5 py-6 text-center text-[#166534] shadow-[0_10px_24px_rgba(22,101,52,0.12)]">
+              <p className="text-base font-semibold">Tudo certo! 🌱</p>
+              <p className="mt-2 text-sm leading-relaxed">
+                Recebemos seu pedido de acesso antecipado. Entraremos em contato assim que houver novidades.
+              </p>
             </div>
           ) : (
             <form onSubmit={handleSubmit} className="space-y-8">
-              <div>
-                <p className="text-sm text-gray-300 mb-3">Informações pessoais</p>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <fieldset className="space-y-4">
+                <legend className="text-sm font-semibold uppercase tracking-[0.18em] text-[#6B7280]">
+                  Informações pessoais
+                </legend>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   <input
                     type="text"
                     name="nome"
@@ -112,7 +125,7 @@ const AcessoAntecipadoPage: React.FC = () => {
                     required
                     value={formData.nome}
                     onChange={handleChange}
-                    className="bg-transparent text-white placeholder-white p-3 rounded-xl w-full border border-white/20 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition"
+                    className="w-full rounded-[14px] border border-[#E5E7EB] bg-white px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] shadow-[0_4px_16px_rgba(15,23,42,0.04)] focus:border-[#3B82F6] focus:outline-none focus:ring-2 focus:ring-[#3B82F6]/30"
                   />
                   <input
                     type="text"
@@ -121,7 +134,7 @@ const AcessoAntecipadoPage: React.FC = () => {
                     required
                     value={formData.sobrenome}
                     onChange={handleChange}
-                    className="bg-transparent text-white placeholder-white p-3 rounded-xl w-full border border-white/20 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition"
+                    className="w-full rounded-[14px] border border-[#E5E7EB] bg-white px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] shadow-[0_4px_16px_rgba(15,23,42,0.04)] focus:border-[#3B82F6] focus:outline-none focus:ring-2 focus:ring-[#3B82F6]/30"
                   />
                 </div>
                 <input
@@ -131,7 +144,7 @@ const AcessoAntecipadoPage: React.FC = () => {
                   required
                   value={formData.email}
                   onChange={handleChange}
-                  className="mt-4 bg-transparent text-white placeholder-white p-3 rounded-xl w-full border border-white/20 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition"
+                  className="w-full rounded-[14px] border border-[#E5E7EB] bg-white px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] shadow-[0_4px_16px_rgba(15,23,42,0.04)] focus:border-[#3B82F6] focus:outline-none focus:ring-2 focus:ring-[#3B82F6]/30"
                 />
                 <InputMask
                   mask="(99) 99999-9999"
@@ -143,94 +156,99 @@ const AcessoAntecipadoPage: React.FC = () => {
                       {...inputProps}
                       type="tel"
                       name="telefone"
-                      placeholder="Seu telefone"
+                      placeholder="Telefone com DDD"
                       required
-                      className="mt-4 bg-transparent text-white placeholder-white p-3 rounded-xl w-full border border-white/20 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition"
+                      className="w-full rounded-[14px] border border-[#E5E7EB] bg-white px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] shadow-[0_4px_16px_rgba(15,23,42,0.04)] focus:border-[#3B82F6] focus:outline-none focus:ring-2 focus:ring-[#3B82F6]/30"
                     />
                   )}
                 </InputMask>
-              </div>
+              </fieldset>
 
-              <div>
-                <p className="text-sm text-gray-300 mb-3">Quando você pensa em conversar com a Eco, qual dessas opções te descreve melhor?</p>
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-semibold uppercase tracking-[0.18em] text-[#6B7280]">
+                  Sua relação com a Eco
+                </legend>
                 <div className="space-y-2">
                   {[
-                    'Estou vivendo algo emocionalmente difícil',
-                    'Quero entender melhor o que estou sentindo',
-                    'Tenho curiosidade sobre mim mesmo(a)',
-                    'Apenas quero experimentar a Eco'
+                    "Estou vivendo algo emocionalmente difícil",
+                    "Quero entender melhor o que estou sentindo",
+                    "Tenho curiosidade sobre mim mesmo(a)",
+                    "Apenas quero experimentar a Eco",
                   ].map((opcao) => (
-                    <label key={opcao} className="flex items-center gap-2 text-white hover:text-indigo-300 cursor-pointer transition text-sm">
+                    <label key={opcao} className="flex items-start gap-3 rounded-[14px] border border-transparent bg-white/60 px-4 py-3 text-sm text-[#4B5563] shadow-[0_4px_16px_rgba(15,23,42,0.04)] transition hover:border-[#D1D5DB]">
                       <input
                         type="radio"
                         name="motivacao"
                         value={opcao}
-                        onChange={() => handleRadioChange('motivacao', opcao)}
-                        className="accent-indigo-400 w-4 h-4"
+                        onChange={() => handleRadioChange("motivacao", opcao)}
+                        className="mt-1 h-4 w-4 accent-[#3B82F6]"
                         required
                       />
-                      {opcao}
+                      <span className="leading-relaxed">{opcao}</span>
                     </label>
                   ))}
                 </div>
-              </div>
+              </fieldset>
 
-              <div>
-                <p className="text-sm text-gray-300 mb-3">Você sente que tem facilidade em nomear suas emoções?</p>
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-semibold uppercase tracking-[0.18em] text-[#6B7280]">
+                  Como você nomeia emoções hoje?
+                </legend>
                 <div className="space-y-2">
-                  {['Sim', 'Às vezes', 'Não sei bem o que sinto'].map((opcao) => (
-                    <label key={opcao} className="flex items-center gap-2 text-white hover:text-indigo-300 cursor-pointer transition text-sm">
+                  {["Sim", "Às vezes", "Não sei bem o que sinto"].map((opcao) => (
+                    <label key={opcao} className="flex items-center gap-3 rounded-[14px] border border-transparent bg-white/60 px-4 py-3 text-sm text-[#4B5563] shadow-[0_4px_16px_rgba(15,23,42,0.04)] transition hover:border-[#D1D5DB]">
                       <input
                         type="radio"
                         name="emocao"
                         value={opcao}
-                        onChange={() => handleRadioChange('emocao', opcao)}
-                        className="accent-indigo-400 w-4 h-4"
+                        onChange={() => handleRadioChange("emocao", opcao)}
+                        className="h-4 w-4 accent-[#3B82F6]"
                         required
                       />
-                      {opcao}
+                      <span>{opcao}</span>
                     </label>
                   ))}
                 </div>
-              </div>
+              </fieldset>
 
-              <div className="space-y-3 text-sm text-white mt-6">
-                <label className="flex items-center gap-2">
+              <div className="space-y-3 text-sm text-[#4B5563]">
+                <p className="font-medium text-[#6B7280]">Como prefere ser avisado?</p>
+                <label className="flex items-center gap-3">
                   <input
                     type="checkbox"
                     name="consentimento_email"
                     checked={formData.consentimento_email}
                     onChange={handleChange}
-                    className="accent-indigo-400"
+                    className="h-4 w-4 accent-[#3B82F6]"
                   />
-                  Concordo em receber o link de acesso por e-mail
+                  <span>Concordo em receber o link de acesso por e-mail</span>
                 </label>
-                <label className="flex items-center gap-2">
+                <label className="flex items-center gap-3">
                   <input
                     type="checkbox"
                     name="consentimento_whatsapp"
                     checked={formData.consentimento_whatsapp}
                     onChange={handleChange}
-                    className="accent-indigo-400"
+                    className="h-4 w-4 accent-[#3B82F6]"
                   />
-                  Concordo em receber o link de acesso por WhatsApp
+                  <span>Concordo em receber o link de acesso por WhatsApp</span>
                 </label>
               </div>
 
               <button
                 type="submit"
                 disabled={!formData.consentimento_email && !formData.consentimento_whatsapp}
-                className={`w-full font-medium py-3 rounded-xl transition-all duration-300 shadow-md ${
+                className={`w-full rounded-full px-6 py-3 text-sm font-semibold shadow-[0_16px_32px_rgba(59,130,246,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
                   formData.consentimento_email || formData.consentimento_whatsapp
-                    ? 'bg-indigo-500 text-white hover:bg-indigo-600 hover:shadow-lg active:scale-[0.98]'
-                    : 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                    ? "bg-[#3B82F6] text-white hover:bg-[#2563EB]"
+                    : "cursor-not-allowed bg-[#E5E7EB] text-[#9CA3AF] shadow-none"
                 }`}
               >
-                Obtenha acesso antecipado 
+                Enviar pedido de acesso
               </button>
             </form>
           )}
-        </div>
+        </section>
       </main>
 
       <Footer />

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -73,7 +73,7 @@ const HeroSection: React.FC = () => {
           <a
             href="https://ecofrontend888.vercel.app/login"
             aria-label="Começar minha jornada"
-            className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-gradient-to-r from-[#4F46E5] to-[#6366F1] px-8 py-3 text-base font-semibold text-white shadow-[0_18px_36px_rgba(99,102,241,0.28)] transition duration-300 ease-out hover:shadow-[0_22px_44px_rgba(99,102,241,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-[#3B82F6] px-8 py-3 text-base font-semibold text-white shadow-[0_16px_32px_rgba(59,130,246,0.28)] transition duration-300 ease-out hover:bg-[#2563EB] hover:shadow-[0_22px_44px_rgba(59,130,246,0.32)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
           >
             <PlayCircle size={18} className="opacity-90" />
             Começar minha jornada
@@ -82,7 +82,7 @@ const HeroSection: React.FC = () => {
           <a
             href="#como-funciona"
             onClick={handleGoToHowItWorks}
-            className="group inline-flex w-full items-center justify-center gap-2 rounded-full border border-[#E0E7FF] bg-white/80 px-8 py-3 text-base font-semibold text-[#4F46E5] shadow-sm transition duration-300 ease-out hover:border-[#C7D2FE] hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#A78BFA] focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
+            className="group inline-flex w-full items-center justify-center gap-2 rounded-full border border-[#D1D5DB] bg-white/80 px-8 py-3 text-base font-semibold text-[#3B82F6] shadow-[0_8px_24px_rgba(15,23,42,0.06)] transition duration-300 ease-out hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3B82F6]/30 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:w-auto"
             aria-label="Ver como funciona"
           >
             Ver como funciona


### PR DESCRIPTION
## Summary
- refresh global layout and hero calls-to-action with a restrained SF Pro driven palette and updated glass effects
- redesign navigation and footer into lightweight translucent cards with consistent Apple-inspired spacing and iconography
- rebuild the access request page with bright surfaces, soft shadows, and streamlined form controls for a calmer experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97a74f1e4832586e94ac095887614