### PR TITLE
Refine eco bubble styling

### DIFF
--- a/src/components/EcoBubbleOneEye.tsx
+++ b/src/components/EcoBubbleOneEye.tsx
@@ -6,16 +6,16 @@ import EyeBubbleBase, {
 const ecoBubbleToken: EyeBubbleToken = {
   id: "eco-bubble-one-eye",
   background:
-    "radial-gradient(circle at 20% 20%, rgba(224, 255, 222, 0.85), rgba(16, 185, 129, 0.85) 42%, rgba(5, 150, 105, 0.95) 100%)",
+    "radial-gradient(circle at 22% 18%, rgba(232, 244, 255, 0.92), rgba(125, 211, 252, 0.82) 44%, rgba(59, 130, 246, 0.9) 78%, rgba(30, 64, 175, 0.95) 100%)",
   border: { color: "rgba(255, 255, 255, 0.45)", width: 1 },
-  glowColor: "rgba(16, 185, 129, 0.35)",
-  textColor: "#022c22",
-  accentColor: "#22d3ee",
+  glowColor: "rgba(59, 130, 246, 0.3)",
+  textColor: "#0f172a",
+  accentColor: "#38bdf8",
   irisGradient:
-    "radial-gradient(circle at 50% 45%, rgba(34, 211, 238, 0.8), rgba(6, 182, 212, 0.85) 35%, rgba(22, 101, 216, 0.95) 75%)",
+    "radial-gradient(circle at 48% 42%, rgba(191, 219, 254, 0.85), rgba(96, 165, 250, 0.88) 36%, rgba(37, 99, 235, 0.96) 74%, rgba(30, 64, 175, 0.98) 100%)",
   pupilColor: "rgba(2, 6, 23, 0.95)",
   reflectionColor: "rgba(255, 255, 255, 0.75)",
-  highlightColor: "rgba(255, 255, 255, 0.35)",
+  highlightColor: "rgba(125, 211, 252, 0.65)",
   minHeight: 360,
 };
 
@@ -33,50 +33,11 @@ export type EcoBubbleOneEyeProps = {
 
 const EcoBubbleOneEye = ({ className }: EcoBubbleOneEyeProps) => {
   return (
-    <EyeBubbleBase token={ecoBubbleToken} motionConfig={ecoMotion} className={className}>
-      <div className="relative flex w-full flex-1 flex-col items-center justify-center gap-6">
-        <div className="relative flex items-center justify-center">
-          <div
-            className="relative h-32 w-32 rounded-full shadow-[0_22px_40px_rgba(13,148,136,0.4)]"
-            style={{ background: ecoBubbleToken.irisGradient }}
-          >
-            <div
-              className="absolute inset-8 rounded-full"
-              style={{ background: ecoBubbleToken.pupilColor }}
-            />
-            <div
-              className="absolute left-3 top-6 h-10 w-10 rounded-full blur-[1px]"
-              style={{ background: ecoBubbleToken.reflectionColor, opacity: 0.7 }}
-            />
-            <div className="absolute right-4 bottom-6 h-6 w-6 rounded-full bg-white/40 blur-sm" />
-          </div>
-          <div
-            className="pointer-events-none absolute inset-x-4 top-1 h-6 rounded-full blur-lg"
-            style={{ background: ecoBubbleToken.highlightColor }}
-          />
-          <div className="pointer-events-none absolute inset-x-10 bottom-0 h-4 rounded-full bg-emerald-900/20 blur-lg" />
-        </div>
-        <div className="space-y-2 text-emerald-950">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-700/60">
-            Eco Vision
-          </p>
-          <h3 className="text-xl font-semibold leading-tight">
-            Monitoramento inteligente de sustentabilidade
-          </h3>
-          <p className="text-sm text-emerald-800/70">
-            Acompanhe indicadores ambientais em tempo real com uma interface inspirada na biomimética.
-          </p>
-        </div>
-        <div className="flex items-center gap-3 text-xs font-medium text-emerald-950/80">
-          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/60 shadow-inner">
-            92%
-          </span>
-          <span className="rounded-full bg-emerald-900/10 px-4 py-2">
-            Índice médio de neutralidade de carbono
-          </span>
-        </div>
-      </div>
-    </EyeBubbleBase>
+    <EyeBubbleBase
+      token={ecoBubbleToken}
+      motionConfig={ecoMotion}
+      className={className}
+    />
   );
 };
 

--- a/src/components/EyeBubbleBase.tsx
+++ b/src/components/EyeBubbleBase.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, PropsWithChildren } from "react";
+import { CSSProperties } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 
 type SizeToken =
@@ -34,11 +34,11 @@ export type EyeBubbleToken = {
   highlightColor?: string;
 };
 
-type EyeBubbleBaseProps = PropsWithChildren<{
+type EyeBubbleBaseProps = {
   token: EyeBubbleToken;
   motionConfig?: MotionConfig;
   className?: string;
-}>;
+};
 
 const defaultMotion: Required<MotionConfig> = {
   floatAmplitude: 12,
@@ -55,7 +55,6 @@ export function EyeBubbleBase({
   token,
   motionConfig,
   className,
-  children,
 }: EyeBubbleBaseProps) {
   const prefersReducedMotion = useReducedMotion();
   const config = { ...defaultMotion, ...motionConfig };
@@ -108,11 +107,37 @@ export function EyeBubbleBase({
       whileHover={hover}
       transition={{ duration: 0.8, ease: "easeOut" }}
     >
-      <div className="pointer-events-none absolute -top-24 left-16 h-48 w-48 rounded-full bg-white/15 blur-3xl" />
-      <div className="pointer-events-none absolute -bottom-28 right-12 h-60 w-60 rounded-full bg-white/10 blur-3xl" />
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-black/10" />
-      <div className="relative z-10 flex w-full flex-1 flex-col items-center justify-center">
-        {children}
+      <div className="pointer-events-none absolute -top-20 left-12 h-44 w-44 rounded-full bg-white/20 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-24 right-10 h-56 w-56 rounded-full bg-white/10 blur-3xl" />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/15 via-transparent to-black/15" />
+      <div className="relative z-10 flex w-full flex-1 items-center justify-center py-6">
+        <div className="relative aspect-square w-[min(260px,72%)] max-w-[320px]">
+          <div
+            className="absolute inset-0 rounded-full shadow-[0_22px_48px_rgba(15,23,42,0.35)]"
+            style={{ background: token.background }}
+          >
+            <div className="absolute inset-[10%] rounded-full border border-white/30" />
+            <div
+              className="absolute inset-[16%] rounded-full"
+              style={{ background: token.irisGradient }}
+            />
+            <div
+              className="absolute inset-[34%] rounded-full"
+              style={{ background: token.pupilColor }}
+            />
+            <div
+              className="absolute left-[24%] top-[26%] h-[28%] w-[28%] rounded-full blur-[1px]"
+              style={{
+                background: token.reflectionColor,
+                opacity: 0.75,
+              }}
+            />
+            <div
+              className="absolute right-[22%] bottom-[24%] h-[16%] w-[16%] rounded-full blur-sm"
+              style={{ background: token.highlightColor, opacity: 0.6 }}
+            />
+          </div>
+        </div>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- retheme the eco bubble token with blue gradients for the bubble, iris, and highlights
- rebuild EyeBubbleBase to render the concentric eye bubble without text blocks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea98608b88325881cc75597ff5645